### PR TITLE
Flexible Post Card w/ Analytics

### DIFF
--- a/PennMobile/Home/Cells/Post/HomePostCell.swift
+++ b/PennMobile/Home/Cells/Post/HomePostCell.swift
@@ -129,7 +129,7 @@ extension HomePostCell {
     
     @objc fileprivate func handleTapped(_ sender: Any) {
         guard let delegate = delegate as? URLSelectable, let url = post.postUrl else { return }
-        let title: String = url.getMatches(for: "https:\\/\\/(.*?)([^a-zA-Z.]|$)").first ?? "View"
+        let title: String = url.getMatches(for: "(http(s?):\\/\\/)?(.*?)(.*?)([^a-zA-Z.]|$)").first ?? "View"
         delegate.handleUrlPressed(url: url, title: title, item: self.item)
     }
 }

--- a/PennMobile/Home/Cells/Post/HomePostCell.swift
+++ b/PennMobile/Home/Cells/Post/HomePostCell.swift
@@ -64,7 +64,7 @@ final class HomePostCell: UITableViewCell, HomeCellConformable {
             subtitleHeight = 0.0
         }
         
-        let bottomSpacing: CGFloat = item.post.source == nil && item.post.subtitle == nil ? 0 : 12
+        let bottomSpacing: CGFloat = item.post.source == nil && item.post.title == nil ? 0 : 12
         return imageHeight + HomeViewController.cellSpacing + titleHeight + subtitleHeight + sourceHeight + bottomSpacing
     }
     
@@ -129,7 +129,8 @@ extension HomePostCell {
     
     @objc fileprivate func handleTapped(_ sender: Any) {
         guard let delegate = delegate as? URLSelectable, let url = post.postUrl else { return }
-        delegate.handleUrlPressed(url: url, title: post.source ?? "View", item: self.item)
+        let title: String = url.getMatches(for: "https:\\/\\/(.*?)([^a-zA-Z.]|$)").first ?? "View"
+        delegate.handleUrlPressed(url: url, title: title, item: self.item)
     }
 }
 

--- a/PennMobile/Home/Cells/Post/HomePostCell.swift
+++ b/PennMobile/Home/Cells/Post/HomePostCell.swift
@@ -15,9 +15,9 @@ final class HomePostCell: UITableViewCell, HomeCellConformable {
     var item: ModularTableViewItem! {
         didSet {
             guard let item = item as? HomePostCellItem else { return }
-            if item.post.description != nil && descriptionLabel == nil {
+            if item.post.subtitle != nil && descriptionLabel == nil {
                 self.prepareDescriptionLabel()
-            } else if item.post.description == nil && descriptionLabel != nil {
+            } else if item.post.subtitle == nil && descriptionLabel != nil {
                 descriptionLabel.removeFromSuperview()
                 descriptionLabel = nil
             }
@@ -34,34 +34,38 @@ final class HomePostCell: UITableViewCell, HomeCellConformable {
     
     static let descriptionFont: UIFont = UIFont(name: "HelveticaNeue", size: 14)!
     
-    private static var titleHeightDictionary = [String: CGFloat]()
-    private static var descriptionHeightDictionary = [String: CGFloat]()
+    private static var titleHeightDictionary = [Int: CGFloat]()
+    private static var subtitleHeightDictionary = [Int: CGFloat]()
     
     static func getCellHeight(for item: ModularTableViewItem) -> CGFloat {
         guard let item = item as? HomePostCellItem else { return 0 }
+        let sourceHeight: CGFloat = item.post.source == nil ? 0 : 26
         let imageHeight = getImageHeight()
         let width: CGFloat = UIScreen.main.bounds.width - 2 * 20 - 2 * titleEdgeOffset
         
         let titleHeight: CGFloat
-        if let height = titleHeightDictionary[item.post.title] {
+        if let height = titleHeightDictionary[item.post.id] {
             titleHeight = height
+        } else if let title = item.post.title {
+            let spacing: CGFloat = item.post.source == nil ? 12 : 8
+            titleHeight = title.dynamicHeight(font: titleFont, width: width) + spacing
+            titleHeightDictionary[item.post.id] = titleHeight
         } else {
-            titleHeight = item.post.title.dynamicHeight(font: titleFont, width: width)
-            titleHeightDictionary[item.post.title] = titleHeight
+            titleHeight = 0.0
         }
         
-        let height = imageHeight + HomeViewController.cellSpacing + titleHeight + 48
-        guard let description = item.post.description else {
-            return height
-        }
-        let descriptionHeight: CGFloat
-        if let height = descriptionHeightDictionary[description] {
-            descriptionHeight = height
+        let subtitleHeight: CGFloat
+        if let height = subtitleHeightDictionary[item.post.id] {
+            subtitleHeight = height
+        } else if let subtitle = item.post.subtitle {
+            subtitleHeight = subtitle.dynamicHeight(font: descriptionFont, width: width) + 6
+            subtitleHeightDictionary[item.post.id] = subtitleHeight
         } else {
-            descriptionHeight = description.dynamicHeight(font: descriptionFont, width: width) + 4
-            descriptionHeightDictionary[description] = descriptionHeight
+            subtitleHeight = 0.0
         }
-        return height + descriptionHeight
+        
+        let bottomSpacing: CGFloat = item.post.source == nil && item.post.subtitle == nil ? 0 : 12
+        return imageHeight + HomeViewController.cellSpacing + titleHeight + subtitleHeight + sourceHeight + bottomSpacing
     }
     
     // MARK: UI Elements
@@ -74,6 +78,9 @@ final class HomePostCell: UITableViewCell, HomeCellConformable {
     fileprivate var descriptionLabel: UILabel!
     fileprivate var dateLabel: UILabel!
     fileprivate var moreButton: UIButton!
+    
+    fileprivate var titleTopConstraintToImage: NSLayoutConstraint!
+    fileprivate var titleTopConstraintToSource: NSLayoutConstraint!
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -93,8 +100,22 @@ extension HomePostCell {
         self.postImageView.image = item.image
         self.sourceLabel.text = post.source
         self.titleLabel.text = post.title
-        self.descriptionLabel?.text = post.description
-        self.dateLabel.text = post.timestamp
+        self.descriptionLabel?.text = post.subtitle
+        self.dateLabel.text = post.timeLabel
+        
+        if item.post.source == nil {
+            titleTopConstraintToSource.isActive = false
+            titleTopConstraintToImage.isActive = true
+        } else {
+            titleTopConstraintToSource.isActive = true
+            titleTopConstraintToImage.isActive = false
+        }
+        
+        if item.post.title == nil && item.post.subtitle == nil {
+            postImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        } else {
+            postImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        }
     }
 }
 
@@ -107,8 +128,8 @@ extension HomePostCell {
     }
     
     @objc fileprivate func handleTapped(_ sender: Any) {
-        guard let delegate = delegate as? URLSelectable else { return }
-        delegate.handleUrlPressed(url: post.postUrl, title: post.source, item: self.item)
+        guard let delegate = delegate as? URLSelectable, let url = post.postUrl else { return }
+        delegate.handleUrlPressed(url: url, title: post.source ?? "View", item: self.item)
     }
 }
 
@@ -123,10 +144,8 @@ extension HomePostCell {
     
     private func prepareImageView() {
         postImageView = UIImageView()
-        if #available(iOS 11.0, *) {
-            postImageView.layer.cornerRadius = cardView.layer.cornerRadius
-            postImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        }
+        postImageView.layer.cornerRadius = cardView.layer.cornerRadius
+        postImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         postImageView.clipsToBounds = true
         postImageView.contentMode = .scaleAspectFill
         
@@ -164,7 +183,10 @@ extension HomePostCell {
         titleLabel.isUserInteractionEnabled = true
         
         cardView.addSubview(titleLabel)
-        _ = titleLabel.anchor(sourceLabel.bottomAnchor, left: cardView.leftAnchor, bottom: nil, right: cardView.rightAnchor, topConstant: 8, leftConstant: HomePostCell.titleEdgeOffset, bottomConstant: 0, rightConstant: HomePostCell.titleEdgeOffset, widthConstant: 0, heightConstant: 0)
+        titleTopConstraintToSource = titleLabel.anchor(sourceLabel.bottomAnchor, left: cardView.leftAnchor, bottom: nil, right: cardView.rightAnchor, topConstant: 8, leftConstant: HomePostCell.titleEdgeOffset, bottomConstant: 0, rightConstant: HomePostCell.titleEdgeOffset, widthConstant: 0, heightConstant: 0)[0]
+        
+        titleTopConstraintToImage = titleLabel.topAnchor.constraint(equalTo: postImageView.bottomAnchor, constant: 12)
+        titleTopConstraintToImage.isActive = false
     }
     
     fileprivate func prepareDescriptionLabel() {

--- a/PennMobile/Home/Cells/Post/HomePostCellItem.swift
+++ b/PennMobile/Home/Cells/Post/HomePostCellItem.swift
@@ -22,8 +22,13 @@ final class HomePostCellItem: HomeCellItem {
     }
     
     static func getItem(for json: JSON?) -> HomeCellItem? {
-        guard let json = json else { return nil }
-        return try? HomePostCellItem(json: json)
+//        let post = Post(source: "Penn Labs", title: "This is a test with a longer sort of subtitle. What do you think?", subtitle: "This is a subtitle with a really really really long subtitle. We can get crazy long if you really really want. If we do this, will you leave?", timeLabel: "Today", imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
+//        let post = Post(source: "Penn Labs", title: "This is a test with a longer sort of subtitle. What do you think?", subtitle: nil, timeLabel: "Today", imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
+        let post = Post(source: "Penn Labs", title: nil, subtitle: "This is a subtitle with a really really really long subtitle. We can get crazy long if you really really want. If we do this, will you leave?", timeLabel: "Today", imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
+//        let post = Post(source: nil, title: nil, subtitle: nil, timeLabel: nil, imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
+        return HomePostCellItem(post: post)
+//        guard let json = json else { return nil }
+        //return try? HomePostCellItem(json: json)
     }
     
     static var associatedCell: ModularTableViewCell.Type {
@@ -51,6 +56,13 @@ extension HomePostCellItem {
     convenience init(json: JSON) throws {
         let post = try Post(json: json)
         self.init(post: post)
+    }
+}
+
+// MARK: - Logging ID
+extension HomePostCellItem: LoggingIdentifiable {
+    var id: String {
+        return String(post.id)
     }
 }
 

--- a/PennMobile/Home/Cells/Post/HomePostCellItem.swift
+++ b/PennMobile/Home/Cells/Post/HomePostCellItem.swift
@@ -22,13 +22,8 @@ final class HomePostCellItem: HomeCellItem {
     }
     
     static func getItem(for json: JSON?) -> HomeCellItem? {
-//        let post = Post(source: "Penn Labs", title: "This is a test with a longer sort of subtitle. What do you think?", subtitle: "This is a subtitle with a really really really long subtitle. We can get crazy long if you really really want. If we do this, will you leave?", timeLabel: "Today", imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
-//        let post = Post(source: "Penn Labs", title: "This is a test with a longer sort of subtitle. What do you think?", subtitle: nil, timeLabel: "Today", imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
-        let post = Post(source: "Penn Labs", title: nil, subtitle: "This is a subtitle with a really really really long subtitle. We can get crazy long if you really really want. If we do this, will you leave?", timeLabel: "Today", imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
-//        let post = Post(source: nil, title: nil, subtitle: nil, timeLabel: nil, imageUrl: "https://i.imgur.com/CmhAG25.jpg", postUrl: "https://pennlabs.org/", id: 1)
-        return HomePostCellItem(post: post)
-//        guard let json = json else { return nil }
-        //return try? HomePostCellItem(json: json)
+        guard let json = json else { return nil }
+        return try? HomePostCellItem(json: json)
     }
     
     static var associatedCell: ModularTableViewCell.Type {

--- a/PennMobile/Home/Cells/Post/Post.swift
+++ b/PennMobile/Home/Cells/Post/Post.swift
@@ -9,35 +9,47 @@
 import Foundation
 
 class Post {
-    let source: String
-    let title: String
-    let description: String?
-    let timestamp: String
+    let source: String?
+    let title: String?
+    let subtitle: String?
+    let timeLabel: String?
     let imageUrl: String
-    let postUrl: String
+    let postUrl: String?
+    let id: Int
     
-    init(source: String, title: String, description: String?, timestamp: String, imageUrl: String, postUrl: String) {
+    init(source: String?, title: String?, subtitle: String?, timeLabel: String?, imageUrl: String, postUrl: String?, id: Int) {
         self.source = source
         self.title = title
-        self.description = description
-        self.timestamp = timestamp
+        self.subtitle = subtitle
+        self.timeLabel = timeLabel
         self.imageUrl = imageUrl
         self.postUrl = postUrl
+        self.id = id
     }
 }
 
 // MARK: - JSON Parsing
 extension Post {
     convenience init(json: JSON) throws {
-        guard let source = json["source"].string,
-            let title = json["title"].string,
-            let timestamp = json["timestamp"].string,
-            let imageUrl = json["image_url"].string,
-            let postUrl = json["post_url"].string else {
-                throw NetworkingError.jsonError
+        guard let imageUrl = json["image_url"].string, let id = json["post_id"].int else {
+            // All posts must have at least an image and an id
+            throw NetworkingError.jsonError
         }
         
-        let description = json["description"].string
-        self.init(source: source, title: title, description: description, timestamp: timestamp, imageUrl: imageUrl, postUrl: postUrl)
+        let source = json["source"].string
+        let title = json["title"].string
+        let subtitle = json["subtitle"].string
+        let postUrl = json["post_url"].string
+        let timeLabel = json["time_label"].string
+        
+        if (source == nil && timeLabel != nil) || (title == nil && subtitle == nil && source != nil) || (title == nil && subtitle != nil) {
+            // Rules:
+            //  (1) A time label cannot exist without a source label
+            //  (2) An image cannot be accompanied with only a source label
+            //  (3) A subtitle cannot exist without a title
+            throw NetworkingError.jsonError
+        }
+        
+        self.init(source: source, title: title, subtitle: subtitle, timeLabel: timeLabel, imageUrl: imageUrl, postUrl: postUrl, id: id)
     }
 }

--- a/PennMobile/Home/Model/HomeItemTypes.swift
+++ b/PennMobile/Home/Model/HomeItemTypes.swift
@@ -67,7 +67,8 @@ extension HomeItemTypes {
      * Note: This method should return an empty array when the app is in production
     **/
     func getDefaultItems() -> [HomeCellItem.Type] {
-        let types = [HomeCellItem.Type]()
+        var types = [HomeCellItem.Type]()
+        types.append(post)
         return types
     }
 }

--- a/PennMobile/Home/Model/HomeItemTypes.swift
+++ b/PennMobile/Home/Model/HomeItemTypes.swift
@@ -67,8 +67,7 @@ extension HomeItemTypes {
      * Note: This method should return an empty array when the app is in production
     **/
     func getDefaultItems() -> [HomeCellItem.Type] {
-        var types = [HomeCellItem.Type]()
-        types.append(post)
+        let types = [HomeCellItem.Type]()
         return types
     }
 }


### PR DESCRIPTION
Flexible post card with post id analytics. Formats include:
- Image only
- Image and title
- Image, title, and subtitle
Source and time labels are always optional but cannot exist on their own
![image](https://user-images.githubusercontent.com/22065307/58218180-fca31280-7cd3-11e9-9716-392ccb890968.png)
![image](https://user-images.githubusercontent.com/22065307/58218185-02005d00-7cd4-11e9-9540-c9c95f417a06.png)
