### PR TITLE
GSR UX Improvement

### DIFF
--- a/PennMobile/GSR-Booking/ViewModel/GSRViewModel.swift
+++ b/PennMobile/GSR-Booking/ViewModel/GSRViewModel.swift
@@ -196,16 +196,72 @@ extension GSRViewModel: GSRSelectionDelegate {
         return true
     }
     
+    private func isValidAddition(timeSlot: GSRTimeSlot) -> Bool {
+        if currentSelection.isEmpty {
+            return true
+        }
+        
+        let isSameRoom = currentSelection.contains(where: { (otherTimeSlot) -> Bool in
+            otherTimeSlot.roomId == timeSlot.roomId
+        })
+        
+        var isBeforeOrAfter = false
+        for selection in currentSelection {
+            isBeforeOrAfter = isBeforeOrAfter || timeSlot == selection.prev || timeSlot == selection.next || timeSlot == selection
+        }
+        
+        return isSameRoom && isBeforeOrAfter
+    }
+    
+    private func isValidRemoval(timeSlot: GSRTimeSlot) -> Bool {
+        if let prev = timeSlot.prev, let next = timeSlot.next,
+            currentSelection.contains(prev) && currentSelection.contains(next) {
+            return false
+        }
+        return true
+    }
+    
+    // Removes all later timeslots including itself from selection
+    private func removeLaterTimeSlotsFromSelection(timeSlot: GSRTimeSlot) {
+        if !currentSelection.contains(timeSlot) { return }
+        if let next = timeSlot.next {
+            removeLaterTimeSlotsFromSelection(timeSlot: next)
+        }
+        currentSelection.remove(at: currentSelection.firstIndex(of: timeSlot)!)
+    }
+    
+    func numberOfLaterSelectedTimeSlots(timeSlot: GSRTimeSlot) -> Int {
+        if !currentSelection.contains(timeSlot) { return 0 }
+        var count = 0
+        if let next = timeSlot.next {
+            count = 1 + numberOfLaterSelectedTimeSlots(timeSlot: next)
+        }
+        return count
+    }
+    
+    // Returns the number to the right removed if any
     func handleSelection(for room: GSRRoom, timeSlot: GSRTimeSlot, action: SelectionType) {
         switch action {
         case .add:
             if currentSelection.contains(timeSlot) { break }
+            if !isValidAddition(timeSlot: timeSlot) {
+                currentSelection.removeAll()
+                delegate.refreshDataUI()
+            }
             currentSelection.append(timeSlot)
             break
         case .remove:
+//            if !isValidRemoval(timeSlot: timeSlot) {
+//                numRemoved = removeLaterTimeSlotsFromSelection(timeSlot: timeSlot)
+//                print(numRemoved)
+////                delegate.refreshDataUI()
+//            } else {
+//                currentSelection.remove(at: currentSelection.firstIndex(of: timeSlot)!)
+//            }
             currentSelection.remove(at: currentSelection.firstIndex(of: timeSlot)!)
             break
         }
+        print(action, currentSelection.map { $0.startTime} )
         
         if currentSelection.count == 0 || (currentSelection.count == 1 && action == .add) {
             delegate.refreshSelectionUI()

--- a/PennMobile/GSR-Booking/ViewModel/GSRViewModel.swift
+++ b/PennMobile/GSR-Booking/ViewModel/GSRViewModel.swift
@@ -160,42 +160,6 @@ extension GSRViewModel: GSRSelectionDelegate {
         return currentSelection.contains(timeSlot)
     }
     
-    func validateChoice(for room: GSRRoom, timeSlot: GSRTimeSlot, action: SelectionType) -> Bool {
-        if !timeSlot.isAvailable {
-            return false
-        }
-        switch action {
-        case .add:
-            return validateAddition(timeSlot)
-        case .remove:
-            return validateRemoval(timeSlot)
-        }
-    }
-    
-    private func validateAddition(_ timeSlot: GSRTimeSlot) -> Bool {
-        if currentSelection.count >= 4 {
-            return false
-        } else if currentSelection.count == 0 {
-            return true
-        }
-        
-        var flag = false
-        for selection in currentSelection {
-            flag = flag || timeSlot == selection.prev || timeSlot == selection.next || timeSlot == selection
-        }
-        return flag
-    }
-    
-    private func validateRemoval(_ timeSlot: GSRTimeSlot) -> Bool {
-        if !currentSelection.contains(timeSlot) {
-            return false
-        } else if let prev = timeSlot.prev, let next = timeSlot.next,
-            currentSelection.contains(prev) && currentSelection.contains(next) {
-            return false
-        }
-        return true
-    }
-    
     private func isValidAddition(timeSlot: GSRTimeSlot) -> Bool {
         if currentSelection.isEmpty {
             return true
@@ -213,32 +177,6 @@ extension GSRViewModel: GSRSelectionDelegate {
         return isSameRoom && isBeforeOrAfter
     }
     
-    private func isValidRemoval(timeSlot: GSRTimeSlot) -> Bool {
-        if let prev = timeSlot.prev, let next = timeSlot.next,
-            currentSelection.contains(prev) && currentSelection.contains(next) {
-            return false
-        }
-        return true
-    }
-    
-    // Removes all later timeslots including itself from selection
-    private func removeLaterTimeSlotsFromSelection(timeSlot: GSRTimeSlot) {
-        if !currentSelection.contains(timeSlot) { return }
-        if let next = timeSlot.next {
-            removeLaterTimeSlotsFromSelection(timeSlot: next)
-        }
-        currentSelection.remove(at: currentSelection.firstIndex(of: timeSlot)!)
-    }
-    
-    func numberOfLaterSelectedTimeSlots(timeSlot: GSRTimeSlot) -> Int {
-        if !currentSelection.contains(timeSlot) { return 0 }
-        var count = 0
-        if let next = timeSlot.next {
-            count = 1 + numberOfLaterSelectedTimeSlots(timeSlot: next)
-        }
-        return count
-    }
-    
     // Returns the number to the right removed if any
     func handleSelection(for room: GSRRoom, timeSlot: GSRTimeSlot, action: SelectionType) {
         switch action {
@@ -251,17 +189,9 @@ extension GSRViewModel: GSRSelectionDelegate {
             currentSelection.append(timeSlot)
             break
         case .remove:
-//            if !isValidRemoval(timeSlot: timeSlot) {
-//                numRemoved = removeLaterTimeSlotsFromSelection(timeSlot: timeSlot)
-//                print(numRemoved)
-////                delegate.refreshDataUI()
-//            } else {
-//                currentSelection.remove(at: currentSelection.firstIndex(of: timeSlot)!)
-//            }
             currentSelection.remove(at: currentSelection.firstIndex(of: timeSlot)!)
             break
         }
-        print(action, currentSelection.map { $0.startTime} )
         
         if currentSelection.count == 0 || (currentSelection.count == 1 && action == .add) {
             delegate.refreshSelectionUI()

--- a/PennMobile/GSR-Booking/ViewModel/GSRViewModel.swift
+++ b/PennMobile/GSR-Booking/ViewModel/GSRViewModel.swift
@@ -177,7 +177,6 @@ extension GSRViewModel: GSRSelectionDelegate {
         return isSameRoom && isBeforeOrAfter
     }
     
-    // Returns the number to the right removed if any
     func handleSelection(for room: GSRRoom, timeSlot: GSRTimeSlot, action: SelectionType) {
         switch action {
         case .add:

--- a/PennMobile/GSR-Booking/Views/RoomCell.swift
+++ b/PennMobile/GSR-Booking/Views/RoomCell.swift
@@ -10,9 +10,7 @@ import UIKit
 
 protocol GSRSelectionDelegate {
     func containsTimeSlot(_ timeSlot: GSRTimeSlot) -> Bool
-    func validateChoice(for room: GSRRoom, timeSlot: GSRTimeSlot, action: SelectionType) -> Bool
     func handleSelection(for room: GSRRoom, timeSlot: GSRTimeSlot, action: SelectionType)
-    func numberOfLaterSelectedTimeSlots(timeSlot: GSRTimeSlot) -> Int
 }
 
 class RoomCell: UITableViewCell {
@@ -77,18 +75,6 @@ extension RoomCell: UICollectionViewDataSource, UICollectionViewDelegate, UIColl
         return CGSize(width: size, height: size)
     }
     
-    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return true
-//        let timeSlot = room.timeSlots[indexPath.row]
-//        return delegate!.validateChoice(for: room, timeSlot: timeSlot, action: SelectionType.add)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
-        return true
-//        let timeSlot = room.timeSlots[indexPath.row]
-//        return delegate!.validateChoice(for: room, timeSlot: timeSlot, action: SelectionType.remove)
-    }
-    
     // MARK: - Collection View Delegate Methods
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let timeSlot = room.timeSlots[indexPath.row]
@@ -109,8 +95,7 @@ extension RoomCell: UICollectionViewDataSource, UICollectionViewDelegate, UIColl
                     if let next = nextTimeSlot.next, room.timeSlots.contains(next) {
                         nextTimeSlot = next
                         nextIndex = IndexPath(row: nextIndex.row + 1, section: indexPath.section)
-                        if let nextCell = collectionView.cellForItem(at: nextIndex), nextCell.isSelected {
-                            
+                        if delegate.containsTimeSlot(nextTimeSlot) {
                             collectionView.deselectItem(at: nextIndex, animated: false)
                             delegate?.handleSelection(for: room, timeSlot: nextTimeSlot, action: SelectionType.remove)
                             let cell = collectionView.cellForItem(at: nextIndex)
@@ -124,6 +109,7 @@ extension RoomCell: UICollectionViewDataSource, UICollectionViewDelegate, UIColl
                 }
             }
         }
+
         delegate?.handleSelection(for: room, timeSlot: timeSlot, action: SelectionType.remove)
         let cell = collectionView.cellForItem(at: indexPath)
         cell?.backgroundColor = .interactionGreen

--- a/PennMobile/GSR-Booking/Views/RoomCell.swift
+++ b/PennMobile/GSR-Booking/Views/RoomCell.swift
@@ -83,35 +83,22 @@ extension RoomCell: UICollectionViewDataSource, UICollectionViewDelegate, UIColl
         cell?.backgroundColor = .informationYellow
     }
     
+    // Deselect this time slot and all select ones that follow it
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        let timeSlot = room.timeSlots[indexPath.row]
-        if let prev = timeSlot.prev, room.timeSlots.contains(prev) {
-            let prevIndex = IndexPath(row: indexPath.row - 1, section: indexPath.section)
-            if let prevCell = collectionView.cellForItem(at: prevIndex), prevCell.isSelected {
-                var checkIfNextCellSelected = true
-                var nextIndex = indexPath
-                var nextTimeSlot = timeSlot
-                while checkIfNextCellSelected {
-                    if let next = nextTimeSlot.next, room.timeSlots.contains(next) {
-                        nextTimeSlot = next
-                        nextIndex = IndexPath(row: nextIndex.row + 1, section: indexPath.section)
-                        if delegate.containsTimeSlot(nextTimeSlot) {
-                            collectionView.deselectItem(at: nextIndex, animated: false)
-                            delegate?.handleSelection(for: room, timeSlot: nextTimeSlot, action: SelectionType.remove)
-                            let cell = collectionView.cellForItem(at: nextIndex)
-                            cell?.backgroundColor = .interactionGreen
-                        } else {
-                            checkIfNextCellSelected = false
-                        }
-                    } else {
-                        checkIfNextCellSelected = false
-                    }
-                }
+        var currTimeSlot = room.timeSlots[indexPath.row]
+        var currIndex = indexPath
+        while delegate.containsTimeSlot(currTimeSlot) {
+            collectionView.deselectItem(at: currIndex, animated: false)
+            delegate?.handleSelection(for: room, timeSlot: currTimeSlot, action: SelectionType.remove)
+            let cell = collectionView.cellForItem(at: currIndex)
+            cell?.backgroundColor = .interactionGreen
+            
+            currIndex = IndexPath(row: currIndex.row + 1, section: currIndex.section)
+            if let nextTimeSlot = currTimeSlot.next {
+                currTimeSlot = nextTimeSlot
+            } else {
+                break
             }
         }
-
-        delegate?.handleSelection(for: room, timeSlot: timeSlot, action: SelectionType.remove)
-        let cell = collectionView.cellForItem(at: indexPath)
-        cell?.backgroundColor = .interactionGreen
     }
 }


### PR DESCRIPTION
Subtle but noticeable UX improvement for selecting GSR timeslots. Rather than not allowing the user to select an illegal timeslot (different room, different hours, etc.), we deselect the previous ones. If the user tries to deselect a middle timeslot in a 2 hour booking, we automatically deselect the timeslots to the right, keeping the selection legal.


![Demo](https://user-images.githubusercontent.com/22065307/64499759-68f85080-d288-11e9-8f9b-fd3db4750c35.gif)
