### PR TITLE
Require explicit refresh to update balance if log in fails

### DIFF
--- a/PennMobile/Dining/Cells/DiningHeaderView.swift
+++ b/PennMobile/Dining/Cells/DiningHeaderView.swift
@@ -104,9 +104,8 @@ extension DiningHeaderView {
     }
     
     @objc fileprivate func refreshButtonTapped(_ sender: Any) {
-        if state == .refresh, let delegate = delegate {
+        if let delegate = delegate {
             delegate.refreshBalance()
-            state = .loading
         }
     }
 }

--- a/PennMobile/Dining/Controllers/DiningViewController.swift
+++ b/PennMobile/Dining/Controllers/DiningViewController.swift
@@ -131,6 +131,7 @@ extension DiningViewController {
                     }
                 }
             } else {
+                self.viewModel.showActivity = false
                 completion?(error)
             }
         }

--- a/PennMobile/Dining/Controllers/DiningViewController.swift
+++ b/PennMobile/Dining/Controllers/DiningViewController.swift
@@ -146,9 +146,7 @@ extension DiningViewController {
     
     @objc fileprivate func handleRefreshControl(_ sender: Any) {
         fetchDiningHours()
-        if UserDefaults.standard.isAuthedIn() {
-            updateBalanceFromCampusExpress()
-        }
+        updateBalanceFromCampusExpress()
     }
 }
 

--- a/PennMobile/General/UserDefaults + Helpers.swift
+++ b/PennMobile/General/UserDefaults + Helpers.swift
@@ -29,6 +29,7 @@ extension UserDefaults {
         case lastLogin
         case unsentLogs
         case lastTransactionRequest
+        case authedIntoShibboleth
     }
 }
 
@@ -319,5 +320,17 @@ extension UserDefaults {
 
     func clearLastTransactionRequest() {
         removeObject(forKey: UserDefaultsKeys.lastTransactionRequest.rawValue)
+    }
+}
+
+// MARK: - Authed Into Shibboleth
+extension UserDefaults {
+    func setShibbolethAuth(authedIn: Bool) {
+        set(authedIn, forKey: UserDefaultsKeys.authedIntoShibboleth.rawValue)
+        synchronize()
+    }
+    
+    func isAuthedIn() -> Bool {
+        return bool(forKey: UserDefaultsKeys.authedIntoShibboleth.rawValue)
     }
 }

--- a/PennMobile/Setup + Navigation/RootViewController.swift
+++ b/PennMobile/Setup + Navigation/RootViewController.swift
@@ -29,6 +29,11 @@ class RootViewController: UIViewController {
         
         if UserDefaults.standard.isNewAppVersion() {
             UserDefaults.standard.setAppVersion()
+            if UserDefaults.standard.getAccountID() != nil {
+                // Upon updating the app, assume everyone with an account is authed into Shibboleth
+                // REMOVE IN FUTURE VERSIONS
+                UserDefaults.standard.setShibbolethAuth(authedIn: true)
+            }
         }
         
         if UserDefaults.standard.getAccountID() != nil && shouldRequireLogin() {

--- a/PennMobile/Setup + Navigation/RootViewController.swift
+++ b/PennMobile/Setup + Navigation/RootViewController.swift
@@ -85,11 +85,13 @@ class RootViewController: UIViewController {
         
         // Fetch transaction data at least once a week, starting on Sundays
         if shouldFetchTransactions() {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                PennCashNetworkManager.instance.getTransactionHistory { data in
-                    if let data = data, let str = String(bytes: data, encoding: .utf8) {
-                        UserDBManager.shared.saveTransactionData(csvStr: str)
-                        UserDefaults.standard.setLastTransactionRequest()
+            if UserDefaults.standard.isAuthedIn() {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    PennCashNetworkManager.instance.getTransactionHistory { data in
+                        if let data = data, let str = String(bytes: data, encoding: .utf8) {
+                            UserDBManager.shared.saveTransactionData(csvStr: str)
+                            UserDefaults.standard.setLastTransactionRequest()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Stop trying to log in to Campus Express to get dining balance if the previous attempt failed. Require the user to explicitly refresh their balance. 