### PR TITLE
Fixing Dining Balance Display Bug

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -724,6 +724,7 @@
 			isa = PBXGroup;
 			children = (
 				216640911EBADC1700746B8E /* DiningViewController.swift */,
+				217C6DD320139A1800F07C3D /* DiningViewModel.swift */,
 				139139762388923E00C6C298 /* DiningDollarsTransactionViewController.swift */,
 			);
 			path = Controllers;
@@ -1033,7 +1034,6 @@
 		975BC27F20F07664009F93AB /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				217C6DD320139A1800F07C3D /* DiningViewModel.swift */,
 				216640901EBADC1700746B8E /* DiningCell.swift */,
 				217C6DDA20139AEE00F07C3D /* DiningHeaderView.swift */,
 				C11B38E4225126DD009B752A /* DiningBalanceCell.swift */,

--- a/PennMobile/Dining/Controllers/DiningViewController.swift
+++ b/PennMobile/Dining/Controllers/DiningViewController.swift
@@ -35,13 +35,17 @@ class DiningViewController: GenericTableViewController {
         super.viewWillAppear(animated)
         fetchDiningHours()
         
-        if viewModel.shouldShowDiningBalances {
+        UserDefaults.standard.set(hasDiningPlan: false)
+        if UserDefaults.standard.hasDiningPlan() {
             if viewModel.balance == nil {
                 fetchBalance()
             } else {
                 updateBalanceIfNeeded()
             }
+        } else {
+            viewModel.balance = DiningBalance(diningDollars: 0, visits: 0, guestVisits: 0, lastUpdated: Date())
         }
+        
         if viewModel.venues[.dining]?.isEmpty ?? true {
             viewModel.refresh()
             tableView.reloadData()
@@ -156,7 +160,7 @@ extension DiningViewController {
     
     @objc fileprivate func handleRefreshControl(_ sender: Any) {
         fetchDiningHours()
-        if viewModel.shouldShowDiningBalances {
+        if UserDefaults.standard.hasDiningPlan() {
             updateBalanceFromCampusExpress(requestLoginOnFail: true)
         }
     }

--- a/PennMobile/Dining/Controllers/DiningViewController.swift
+++ b/PennMobile/Dining/Controllers/DiningViewController.swift
@@ -35,7 +35,6 @@ class DiningViewController: GenericTableViewController {
         super.viewWillAppear(animated)
         fetchDiningHours()
         
-        UserDefaults.standard.set(hasDiningPlan: false)
         if UserDefaults.standard.hasDiningPlan() {
             if viewModel.balance == nil {
                 fetchBalance()

--- a/PennMobile/Dining/Controllers/DiningViewModel.swift
+++ b/PennMobile/Dining/Controllers/DiningViewModel.swift
@@ -30,19 +30,12 @@ class DiningViewModel: NSObject {
     internal let diningCell = "diningCell"
     internal let diningBalanceCell = "diningBalanceCell"
     
-    var shouldShowDiningBalances: Bool {
-        get {
-            return UserDefaults.standard.hasDiningPlan()
-        }
-    }
-    
     func refresh() {
         self.venues = DiningDataStore.shared.getSectionedVenues()
     }
     
     func getType(forSection section: Int) -> DiningVenue.VenueType {
-        let index = shouldShowDiningBalances ? section - 1 : section
-        return ordering[index]
+        return ordering[section - 1]
     }
     
     func getVenues(forSection section: Int) -> [DiningVenue] {
@@ -58,18 +51,15 @@ class DiningViewModel: NSObject {
 // MARK: - UITableViewDataSource
 extension DiningViewModel: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return ordering.count + (shouldShowDiningBalances ? 1 : 0)
+        return ordering.count + 1
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if shouldShowDiningBalances && section == 0 {
-            return 1
-        }
-        return getVenues(forSection: section).count
+        return section == 0 ? 1 : getVenues(forSection: section).count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if shouldShowDiningBalances && indexPath.section == 0 {
+        if indexPath.section == 0 {
             let cell = tableView.dequeueReusableCell(withIdentifier: diningBalanceCell, for: indexPath) as! DiningBalanceCell
             cell.selectionStyle = .none
             cell.diningBalance = balance
@@ -91,14 +81,13 @@ extension DiningViewModel: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 extension DiningViewModel: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if shouldShowDiningBalances && section == 0 {
+        if section == 0 {
             let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerView) as! DiningHeaderView
             view.label.text = balancesHeader
             view.state = showActivity ? .loading : .refresh
             view.delegate = self.delegate
             return view
-        }
-        else {
+        } else {
             let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerView) as! DiningHeaderView
             
             let headerTitle: String
@@ -116,10 +105,7 @@ extension DiningViewModel: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if shouldShowDiningBalances && indexPath.section == 0 {
-            return DiningBalanceCell.cellHeight
-        }
-        return DiningCell.cellHeight
+        return indexPath.section == 0 ? DiningBalanceCell.cellHeight : DiningCell.cellHeight
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -127,7 +113,7 @@ extension DiningViewModel: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if shouldShowDiningBalances && indexPath.section > 0 || !shouldShowDiningBalances {
+        if indexPath.section > 0 {
             let venue = getVenue(for: indexPath)
             delegate?.handleSelection(for: venue)
         }


### PR DESCRIPTION
This PR fixes the dining dollar bug that was causing the app to show some user's balance. All users now see the dining balance UI, even if the app determines they do not have a balance. This fixes the previous issue, which was caused by the app incorrectly inferring whether or not someone had a balance. Note that if the app knows a user doesn't have a balance, it does not proactively attempt to fetch a new one from CampusExpress unless explicitly told to refresh.

![image](https://user-images.githubusercontent.com/22065307/71293405-48d63400-2343-11ea-872d-026677e3471a.png)
