### PR TITLE
Automatic Debug Mode

### DIFF
--- a/PennMobile/General/Networking + Analytics/FeedAnalyticsEngine.swift
+++ b/PennMobile/General/Networking + Analytics/FeedAnalyticsEngine.swift
@@ -9,7 +9,13 @@
 import Foundation
 
 class FeedAnalyticsManager: NSObject, Requestable {
-    var dryRun: Bool = false
+    var dryRun: Bool {
+        #if DEBUG
+           return true
+        #else
+            return false
+        #endif
+    }
     
     fileprivate let eventSeparationMinimum = 30 // 30 minutes must pass for cell to be tracked twice
     fileprivate let defaultBatchSize = 5 // Send all events if at least 8 cells have been tracked
@@ -30,6 +36,7 @@ class FeedAnalyticsManager: NSObject, Requestable {
     
     func track(cellType: String, index: Int, id: String?, batchSize: Int? = nil) {
         if dryRun { return }
+        
         let event = FeedAnalyticsEvent(cellType: cellType, id: id, index: index, isInteraction: false, timestamp: Date())
         
         var eventAdded = false

--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -11,24 +11,35 @@ import SwiftyJSON
 
 func getDeviceID() -> String {
     let deviceID = UIDevice.current.identifierForVendor!.uuidString
-    return UserDBManager.shared.testRun ? "test" : deviceID
+    #if DEBUG
+       return "test"
+    #else
+        return deviceID
+    #endif
 }
 
 class UserDBManager: NSObject, Requestable {
     static let shared = UserDBManager()
     fileprivate let baseUrl = "https://api.pennlabs.org"
     
-    var dryRun: Bool = true
-    var testRun: Bool = false
+    var dryRun: Bool {
+        get {
+            #if DEBUG
+               return true
+            #else
+                return false
+            #endif
+        }
+    }
     
     fileprivate func sendRequest(_ request: NSMutableURLRequest) {
-        if dryRun && !testRun { return }
+        if dryRun { return }
         let task = URLSession.shared.dataTask(with: request as URLRequest)
         task.resume()
     }
     
     fileprivate func sendRequest(_ request: NSMutableURLRequest, callback: @escaping (Data?, URLResponse?, Error?) -> Void) {
-        if dryRun && !testRun { return }
+        if dryRun { return }
         let task = URLSession.shared.dataTask(with: request as URLRequest, completionHandler: callback)
         task.resume()
     }

--- a/PennMobile/Setup + Navigation/AppDelegate.swift
+++ b/PennMobile/Setup + Navigation/AppDelegate.swift
@@ -27,13 +27,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        // Override point for customization after application launch.
-        UserDBManager.shared.dryRun = true
-        UserDBManager.shared.testRun = true
-        FeedAnalyticsManager.shared.dryRun = true
-
-        FirebaseConfiguration.shared.setLoggerLevel(.min) // Comment out before release
+        #if DEBUG
+           FirebaseConfiguration.shared.setLoggerLevel(.min) // Comment out before release
+        #endif
         
         FirebaseApp.configure()
         ControllerModel.shared.prepare()

--- a/PennMobile/Setup + Navigation/AppDelegate.swift
+++ b/PennMobile/Setup + Navigation/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         #if DEBUG
-           FirebaseConfiguration.shared.setLoggerLevel(.min) // Comment out before release
+           FirebaseConfiguration.shared.setLoggerLevel(.min)
         #endif
         
         FirebaseApp.configure()


### PR DESCRIPTION
This PR simplifies the release process by removing the need to manually change the codebase for production. Previously, certain flags had to be changed to `false`, such as `FeedAnalyticsManager.shared.dryrun` and certain pieces of code had to be commented out, such as `FirebaseConfiguration.shared.setLoggerLevel(.min)`. This is now handled automatically with `#if Debug`, which is a new feature available in iOS 10.

Example:
```
#if DEBUG
    FirebaseConfiguration.shared.setLoggerLevel(.min)
#endif
``` 
**NOTE:** New releases still require a change in the build schema and an update to the build and version numbers.