### PR TITLE
Privacy-First Courses Rewrite

### DIFF
--- a/PennMobile/Courses/Course.swift
+++ b/PennMobile/Courses/Course.swift
@@ -24,8 +24,8 @@ class Course: Codable, Hashable {
     let weekdays: String
     let startDate: String?
     let endDate: String?
-    let startTime: String
-    let endTime: String
+    var startTime: String
+    var endTime: String
     let instructors: [String]
     
     let meetingTimes: [CourseMeetingTime]?
@@ -112,7 +112,12 @@ extension Course {
     
     func isTaughtInNDays(days: Int) -> Bool {
         let weekday = Date().integerDayOfWeek
-        return weekdays.contains(Course.weekdayAbbreviations[(weekday + days) % 7])
+        if let times = meetingTimes {
+            let weekday = Course.weekdayAbbreviations[(weekday + days) % 7]
+            return times.contains { $0.weekday.contains(weekday) }
+        } else {
+            return weekdays.contains(Course.weekdayAbbreviations[(weekday + days) % 7])
+        }
     }
     
     func hasSameMeetingTime(as course: Course) -> Bool {

--- a/PennMobile/Courses/Course.swift
+++ b/PennMobile/Courses/Course.swift
@@ -210,3 +210,23 @@ extension Array where Element == Course {
         return true
     }
 }
+
+extension Course {
+    static var currentTerm: String {
+        let now = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+        let year = formatter.string(from: now)
+        formatter.dateFormat = "M"
+        let month = Int(formatter.string(from: now))!
+        let code: String
+        if month <= 5 {
+            code = "A"
+        } else if month >= 8 {
+            code = "C"
+        } else {
+            code = "B"
+        }
+        return "\(year)\(code)"
+    }
+}

--- a/PennMobile/Courses/CoursesWebviewController.swift
+++ b/PennMobile/Courses/CoursesWebviewController.swift
@@ -28,7 +28,7 @@ class CoursesWebviewController: PennLoginController, IndicatorEnabled {
                     self.saveCoursesAndDismiss(courses)
                 } else {
                     // If unsuccessful, try one more time.
-                    PennInTouchNetworkManager.instance.getCourses(currentTermOnly: true, callback: { (courses) in
+                    PennInTouchNetworkManager.instance.getCourses(currentTermOnly: self.currentTermOnly, callback: { (courses) in
                         DispatchQueue.main.async {
                             decisionHandler(.cancel)
                             self.hideActivity()
@@ -42,7 +42,6 @@ class CoursesWebviewController: PennLoginController, IndicatorEnabled {
     
     private func saveCoursesAndDismiss(_ courses: Set<Course>?) {
         if let courses = courses, let accountID = UserDefaults.standard.getAccountID() {
-            UserDBManager.shared.saveCourses(courses, accountID: accountID)
             UserDBManager.shared.saveCourses(courses, accountID: accountID) { (_) in
                 DispatchQueue.main.async {
                     self.dismiss(animated: true, completion: {

--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -141,41 +141,42 @@ extension UserDBManager {
     }
     
     func saveCourses(_ courses: Set<Course>, accountID: String, _ completion: ((_ success: Bool) -> Void)? = nil) {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
-        do {
-            let url = URL(string: "\(baseUrl)/account/courses")!
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-            
-            let coursesObj = CoursesJSON(accountID: accountID, courses: courses)
-            let jsonData = try jsonEncoder.encode(coursesObj)
-            request.httpBody = jsonData
-            
-            let task = URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
-                var success = false
-                if let httpResponse = response as? HTTPURLResponse {
-                    if httpResponse.statusCode == 200 {
-                        if let data = data, let _ = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
-                            let json = JSON(data)
-                            success = json["success"].boolValue
-                        }
-                    } else {
-                        if let data = data, let _ = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
-                            let json = JSON(data)
-                            let error = json["error"].stringValue
-                            print(error)
-                        }
-                    }
-                }
-                completion?(success)
-            })
-            task.resume()
-        }
-        catch {
-            completion?(false)
-        }
+        completion?(true)
+//        let jsonEncoder = JSONEncoder()
+//        jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
+//        do {
+//            let url = URL(string: "\(baseUrl)/account/courses")!
+//            var request = URLRequest(url: url)
+//            request.httpMethod = "POST"
+//            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+//
+//            let coursesObj = CoursesJSON(accountID: accountID, courses: courses)
+//            let jsonData = try jsonEncoder.encode(coursesObj)
+//            request.httpBody = jsonData
+//
+//            let task = URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
+//                var success = false
+//                if let httpResponse = response as? HTTPURLResponse {
+//                    if httpResponse.statusCode == 200 {
+//                        if let data = data, let _ = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
+//                            let json = JSON(data)
+//                            success = json["success"].boolValue
+//                        }
+//                    } else {
+//                        if let data = data, let _ = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
+//                            let json = JSON(data)
+//                            let error = json["error"].stringValue
+//                            print(error)
+//                        }
+//                    }
+//                }
+//                completion?(success)
+//            })
+//            task.resume()
+//        }
+//        catch {
+//            completion?(false)
+//        }
     }
 }
 

--- a/PennMobile/Home/Cells/Courses/HomeCoursesCellItem.swift
+++ b/PennMobile/Home/Cells/Courses/HomeCoursesCellItem.swift
@@ -75,10 +75,35 @@ extension Set where Element == Course {
     }
     
     var taughtToday: Set<Course> {
-        self.enrolledIn.filter { $0.isTaughtToday }
+        let courses = self.enrolledIn.filter { $0.isTaughtToday }.map { $0.getCourseWithCorrectTime(days: 0) }.flatMap { $0 }
+        return Set(courses)
     }
     
     var taughtTomorrow: Set<Course> {
-        self.enrolledIn.filter { $0.isTaughtTomorrow }
+        let courses = self.enrolledIn.filter { $0.isTaughtTomorrow }.map { $0.getCourseWithCorrectTime(days: 1) }.flatMap { $0 }
+        return Set(courses)
+    }
+}
+
+extension Course {
+    func getCourseWithCorrectTime(days: Int) -> [Course] {
+        var courses = [Course]()
+        let weekday = Course.weekdayAbbreviations[(Date().integerDayOfWeek + days) % 7]
+        if let times = self.meetingTimes {
+            for time in times {
+                if time.weekday.contains(weekday) {
+                    courses.append(self.copy(startTime: time.startTime, endTime: time.endTime))
+                }
+            }
+        }
+        if courses.isEmpty {
+            return [self]
+        } else {
+            return courses
+        }
+    }
+    
+    func copy(startTime: String, endTime: String) -> Course {
+        return Course(name: self.name, term: self.term, dept: self.dept, code: self.code, section: self.section, building: self.building, room: self.room, weekdays: self.weekdays, startDate: self.startDate, endDate: self.endDate, startTime: startTime, endTime: endTime, instructors: self.instructors, meetingTimes: nil)
     }
 }

--- a/PennMobile/Home/Cells/Courses/HomeCoursesCellItem.swift
+++ b/PennMobile/Home/Cells/Courses/HomeCoursesCellItem.swift
@@ -67,7 +67,7 @@ final class HomeCoursesCellItem: HomeCellItem {
 // MARK: - Home Page Logic
 extension Set where Element == Course {
     var enrolledIn: Set<Course> {
-        let nowStr = "2020-02-01"
+        let nowStr = "2019-10-01"
         let term = Course.currentTerm
         let coursesWithDate = self.filter { $0.startDate != nil && $0.endDate != nil }.filter { $0.startDate! <= nowStr && nowStr <= $0.endDate! }
         let coursesWithoutDate = self.filter { $0.startDate == nil || $0.endDate == nil }.filter { $0.term == term }

--- a/PennMobile/Home/Cells/Courses/HomeCoursesCellItem.swift
+++ b/PennMobile/Home/Cells/Courses/HomeCoursesCellItem.swift
@@ -23,13 +23,33 @@ final class HomeCoursesCellItem: HomeCellItem {
     }
     
     static func getItem(for json: JSON?) -> HomeCellItem? {
-        guard let json = json, let weekday = json["weekday"].string, let data: Data = try? json["courses"].rawData()  else { return nil }
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        do {
-            let courses = try decoder.decode([Course].self, from: data)
-            return HomeCoursesCellItem(weekday: weekday, courses: courses)
-        } catch {
+        if let json = json, let weekday = json["weekday"].string, let data: Data = try? json["courses"].rawData() {
+            // Courses provided by server
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            do {
+                let courses = try decoder.decode([Course].self, from: data)
+                return HomeCoursesCellItem(weekday: weekday, courses: courses)
+            } catch {
+                return nil
+            }
+        } else if let courses = UserDefaults.standard.getCourses() {
+            // Courses not provided by server. Use courses saved on device.
+            let coursesToday = courses.taughtToday
+            if !coursesToday.isEmpty {
+                let weekday = "Today"
+                return HomeCoursesCellItem(weekday: weekday, courses: Array(coursesToday))
+            } else {
+                let weekday = "Tomorrow"
+                let coursesTomorrow = courses.taughtTomorrow
+                if !coursesTomorrow.isEmpty {
+                    return HomeCoursesCellItem(weekday: weekday, courses: Array(coursesTomorrow))
+                } else {
+                    return nil
+                }
+            }
+            
+        } else {
             return nil
         }
     }
@@ -41,5 +61,24 @@ final class HomeCoursesCellItem: HomeCellItem {
     func equals(item: ModularTableViewItem) -> Bool {
         guard let item = item as? HomeCoursesCellItem else { return false }
         return weekday == item.weekday
+    }
+}
+
+// MARK: - Home Page Logic
+extension Set where Element == Course {
+    var enrolledIn: Set<Course> {
+        let nowStr = "2020-02-01"
+        let term = Course.currentTerm
+        let coursesWithDate = self.filter { $0.startDate != nil && $0.endDate != nil }.filter { $0.startDate! <= nowStr && nowStr <= $0.endDate! }
+        let coursesWithoutDate = self.filter { $0.startDate == nil || $0.endDate == nil }.filter { $0.term == term }
+        return coursesWithDate.union(coursesWithoutDate)
+    }
+    
+    var taughtToday: Set<Course> {
+        self.enrolledIn.filter { $0.isTaughtToday }
+    }
+    
+    var taughtTomorrow: Set<Course> {
+        self.enrolledIn.filter { $0.isTaughtTomorrow }
     }
 }

--- a/PennMobile/Home/Controllers/HomeViewController + Delegates.swift
+++ b/PennMobile/Home/Controllers/HomeViewController + Delegates.swift
@@ -119,7 +119,7 @@ extension HomeViewController {
     
     // MARK: Course Refresh
     func handleCourseRefresh() {
-        let message = "Has there been a change to your schedule? If so, would you like Penn Mobile to update your courses?"
+        let message = "Has there been a change to your schedule? Would you like Penn Mobile to update your courses?"
         let alert = UIAlertController(title: "Update Courses",
                                       message: message,
                                       preferredStyle: .alert)
@@ -168,6 +168,12 @@ extension HomeViewController: ShowsAlert {
                 } else {
                     self.handleCourseRefresh(courses)
                 }
+                if let currentCourses = UserDefaults.standard.getCourses() {
+                    let term = Course.currentTerm
+                    let currentCoursesMinusTerm = currentCourses.filter { $0.term != term }
+                    let newCourses = currentCoursesMinusTerm.union(courses)
+                    UserDefaults.standard.saveCourses(newCourses)
+                }
             } else {
                 self.showCourseWebviewController()
             }
@@ -177,8 +183,14 @@ extension HomeViewController: ShowsAlert {
     private func handleCourseRefresh(_ courses: Set<Course>?) {
         DispatchQueue.main.async {
             if let courses = courses, let courseItem = self.tableViewModel.getItems(for: [HomeItemTypes.instance.courses]).first as? HomeCoursesCellItem {
-                courseItem.courses = Array(courses).filterByWeekday(for: courseItem.weekday).sorted()
-                self.reloadItem(courseItem)
+                let taughtToday = Array(courses.taughtToday)
+                let taughtTomorrow = Array(courses.taughtTomorrow)
+                if taughtToday.isEmpty && taughtTomorrow.isEmpty {
+                    self.removeItem(courseItem)
+                } else {
+                    courseItem.courses = taughtToday.isEmpty ? taughtTomorrow : taughtToday
+                    self.reloadItem(courseItem)
+                }
                 self.showAlert(withMsg: "Your courses have been updated.", title: "Success!", completion: nil)
             } else {
                 self.showAlert(withMsg: "Unable to access your courses. Please try again later.", title: "Uh oh!", completion: nil)

--- a/PennMobile/Home/Map/MapViewController.swift
+++ b/PennMobile/Home/Map/MapViewController.swift
@@ -64,6 +64,9 @@ class MapViewController: UIViewController {
                 // Do nothing, handle in didChangeAuthorization delegate function
                 self.locationManager.requestWhenInUseAuthorization()
                 break
+            case .denied:
+                self.locationManager.requestWhenInUseAuthorization()
+                break
             default:
                 showCoordinates(searchTerm: searchTerm)
                 break

--- a/PennMobile/Home/Networking/HomeAPIService.swift
+++ b/PennMobile/Home/Networking/HomeAPIService.swift
@@ -19,7 +19,7 @@ final class HomeAPIService: Requestable {
             url = "\(url)&sessionid=\(sessionID)"
         }
         if let courses = UserDefaults.standard.getCourses(), !courses.enrolledIn.isEmpty {
-            if !courses.taughtToday.isEmpty {
+            if courses.taughtToday.hasUpcomingCourse {
                 url = "\(url)&hasCourses=today"
             } else if !courses.taughtTomorrow.isEmpty {
                 url = "\(url)&hasCourses=tomorrow"

--- a/PennMobile/Home/Networking/HomeAPIService.swift
+++ b/PennMobile/Home/Networking/HomeAPIService.swift
@@ -18,6 +18,13 @@ final class HomeAPIService: Requestable {
         if let sessionID = GSRUser.getSessionID() {
             url = "\(url)&sessionid=\(sessionID)"
         }
+        if let courses = UserDefaults.standard.getCourses(), !courses.enrolledIn.isEmpty {
+            if !courses.taughtToday.isEmpty {
+                url = "\(url)&hasCourses=today"
+            } else if !courses.taughtTomorrow.isEmpty {
+                url = "\(url)&hasCourses=tomorrow"
+            }
+        }
         
         OAuth2NetworkManager.instance.getAccessToken { (token) in
             // Make request without access token if one does not exist

--- a/PennMobile/Login/PennInTouchNetworkManager.swift
+++ b/PennMobile/Login/PennInTouchNetworkManager.swift
@@ -57,7 +57,7 @@ extension PennInTouchNetworkManager {
                             
                             let courses = try self.parseCourses(from: html, term: selectedTerm)
                             if currentTermOnly {
-                                let currentTerm = self.currentTerm()
+                                let currentTerm = Course.currentTerm
                                 if selectedTerm == currentTerm {
                                     // If first term in list is the current term, return those courses
                                     callback(courses)
@@ -119,24 +119,6 @@ extension PennInTouchNetworkManager {
             callback(courses)
         }
         task.resume()
-    }
-    
-    private func currentTerm() -> String {
-        let now = Date()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy"
-        let year = formatter.string(from: now)
-        formatter.dateFormat = "M"
-        let month = Int(formatter.string(from: now))!
-        let code: String
-        if month <= 5 {
-            code = "A"
-        } else if month >= 8 {
-            code = "C"
-        } else {
-            code = "B"
-        }
-        return "\(year)\(code)"
     }
 }
 

--- a/PennMobile/Login/PennInTouchNetworkManager.swift
+++ b/PennMobile/Login/PennInTouchNetworkManager.swift
@@ -30,7 +30,6 @@ extension PennInTouchNetworkManager {
                 if let httpResponse = response as? HTTPURLResponse {
                     if httpResponse.statusCode == 200 {
                         if let data = data, let html = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String? {
-                            print(html)
                             let degrees = try? self.parseDegrees(from: html)
                             callback(degrees)
                             return
@@ -48,39 +47,41 @@ extension PennInTouchNetworkManager {
 extension PennInTouchNetworkManager {    
     func getCourses(currentTermOnly: Bool = false, callback: @escaping ((_ courses: Set<Course>?) -> Void)) {
         makeAuthRequest(targetUrl: courseURL, shibbolethUrl: shibbolethUrl) { (data, response, error) in
-            if let httpResponse = response as? HTTPURLResponse {
-                if httpResponse.statusCode == 200 {
-                    if let data = data, let html = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String? {
-                        do {
-                            let terms = try self.parseTerms(from: html)
-                            let selectedTerm = try self.parseSelectedTerm(from: html)
-                            
-                            let courses = try self.parseCourses(from: html, term: selectedTerm)
-                            if currentTermOnly {
-                                let currentTerm = Course.currentTerm
-                                if selectedTerm == currentTerm {
-                                    // If first term in list is the current term, return those courses
-                                    callback(courses)
-                                } else {
-                                    // Otherwise, we need to do another request but for just the current term
-                                    let remainingTerms = [currentTerm]
-                                    self.getCoursesHelper(terms: remainingTerms, courses: Set<Course>(), callback: { (courses) in
+            self.makeAuthRequest(targetUrl: self.courseURL, shibbolethUrl: self.shibbolethUrl) { (data, response, error) in
+                if let httpResponse = response as? HTTPURLResponse {
+                    if httpResponse.statusCode == 200 {
+                        if let data = data, let html = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String? {
+                            do {
+                                let terms = try self.parseTerms(from: html)
+                                let selectedTerm = try self.parseSelectedTerm(from: html)
+                                
+                                let courses = try self.parseCourses(from: html, term: selectedTerm)
+                                if currentTermOnly {
+                                    let currentTerm = Course.currentTerm
+                                    if selectedTerm == currentTerm {
+                                        // If first term in list is the current term, return those courses
                                         callback(courses)
+                                    } else {
+                                        // Otherwise, we need to do another request but for just the current term
+                                        let remainingTerms = [currentTerm]
+                                        self.getCoursesHelper(terms: remainingTerms, courses: Set<Course>(), callback: { (courses) in
+                                            callback(courses)
+                                        })
+                                    }
+                                } else {
+                                    let remainingTerms = terms.filter { $0 != selectedTerm }
+                                    self.getCoursesHelper(terms: remainingTerms, courses: courses, callback: { (allCourses) in
+                                        callback(allCourses)
                                     })
                                 }
-                            } else {
-                                let remainingTerms = terms.filter { $0 != selectedTerm }
-                                self.getCoursesHelper(terms: remainingTerms, courses: courses, callback: { (allCourses) in
-                                    callback(allCourses)
-                                })
+                                return
+                            } catch {
                             }
-                            return
-                        } catch {
                         }
                     }
                 }
+                callback(nil)
             }
-            callback(nil)
         }
     }
     


### PR DESCRIPTION
This PR introduces courses back to the homepage without sending any course data to the server. Previously, the flow was:

1. User logs in and courses are retrieved from PennInTouch
2. Penn Mobile sends courses blob to server, which saves info on the DB
3. User makes a homepage GET request. Server queries the DB to get the user's courses today. If the user has no courses today or if the last course has finished, the server queries the DB to get tomorrow's courses. Card is weighted higher if showing today's courses.
4. Penn Mobile renders the homepage card for the courses provided by the homepage.

Now, the flow is:
1. User logs in and courses are retrieved from PennInTouch
2. Penn Mobile saves the courses in UserDefaults (UD)
3. Before homepage GET request is made, Penn Mobile pulls the courses from UD and queries to see if there are any courses today or tomorrow.
4. Penn Mobile sends flag hasCourses when making homepage GET request. This flag is either "today" or "tomorrow," indicating whether to show today's courses or tomorrow's courses.
5. If the request contains a flag, server creates a blank homepage card with the appropriate weighting depending on if the flag is "today" or "tomorrow" (higher if today).
6. Penn Mobile renders the courses card, displaying the user's courses from UD for today or tomorrow.

![Pasted Graphic 1](https://user-images.githubusercontent.com/22065307/71429788-6d5d4380-2696-11ea-9b29-1b0d20b498bd.png)
