### PR TITLE
College House Privacy-Permission

### DIFF
--- a/PennMobile/About/Privacy/PrivacyPreference.swift
+++ b/PennMobile/About/Privacy/PrivacyPreference.swift
@@ -116,7 +116,7 @@ extension PrivacyOption {
                     }
                 }
             case .collegeHouse:
-                // Save the current semester and then save previous stored in semesters from UserDefaults
+                // Save the current semester and then save previous semesters stored in UserDefaults
                 CampusExpressNetworkManager.instance.updateHousingData { (success) in
                     UserDBManager.shared.saveMultiyearHousingData()
                 }

--- a/PennMobile/About/Privacy/PrivacyPreference.swift
+++ b/PennMobile/About/Privacy/PrivacyPreference.swift
@@ -115,10 +115,16 @@ extension PrivacyOption {
                         UserDBManager.shared.saveCoursesAnonymously(courses)
                     }
                 }
-                // Privacy setting successfully saved even if courses not able to be fetched, so return success
-                completion(true)
-            default: completion(true)
+            case .collegeHouse:
+                // Save the current semester and then save previous stored in semesters from UserDefaults
+                CampusExpressNetworkManager.instance.updateHousingData { (success) in
+                    UserDBManager.shared.saveMultiyearHousingData()
+                }
+            default: break
             }
+            
+            // Privacy setting successfully saved even if data not able to be fetched, so return success
+            completion(true)
         }
     }
     
@@ -136,6 +142,8 @@ extension PrivacyOption {
             case .anonymizedCourseSchedule:
                 UserDefaults.standard.removeObject(forKey: self.didShareKey)
                 UserDBManager.shared.deleteAnonymousCourses(completion)
+            case .collegeHouse:
+                UserDBManager.shared.deleteHousingData(completion)
             default: completion(true)
             }
         }

--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -287,6 +287,7 @@ extension UserDBManager {
 
 // MARK: - Housing Data
 extension UserDBManager {
+    /// Uploads raw CampusExpress housing html to the server, which parses it and saves the corresponding housing result. This result is returned and stored in UserDefaults.
     func saveHousingData(html: String, _ completion: (( _ result: HousingResult?) -> Void)? = nil) {
         let url = "\(baseUrl)/housing"
         let params = ["html": html]
@@ -304,6 +305,7 @@ extension UserDBManager {
         }
     }
     
+    /// Uploads all housing results stored in UserDefaults to the server
     func saveMultiyearHousingData(_ completion: (( _ success: Bool) -> Void)? = nil) {
         guard let housingResults = UserDefaults.standard.getHousingResults() else {
             completion?(true)

--- a/PennMobile/Login/CampusExpressNetworkManager.swift
+++ b/PennMobile/Login/CampusExpressNetworkManager.swift
@@ -28,13 +28,17 @@ extension CampusExpressNetworkManager: PennAuthRequestable {
         return "https://prod.campusexpress.upenn.edu/Shibboleth.sso/SAML2/POST"
     }
     
-    func updateHousingData() {
+    func updateHousingData(_ completion: ((_ success: Bool) -> Void)? = nil) {
         makeAuthRequest(targetUrl: housingUrl, shibbolethUrl: shibbolethUrl) { (data, response, error) in
             if let data = data, let html = NSString(data: data, encoding: String.Encoding.utf8.rawValue) {
                 if let doc = try? SwiftSoup.parse(html as String), let htmlStr = try? doc.body()?.html(), let html = htmlStr {
-                    UserDBManager.shared.saveHousingData(html: html)
+                    UserDBManager.shared.saveHousingData(html: html) { (result) in
+                        completion?(result != nil)
+                    }
+                    return
                 }
             }
+            completion?(false)
         }
     }
     

--- a/PennMobile/Login/LabsLoginController.swift
+++ b/PennMobile/Login/LabsLoginController.swift
@@ -166,11 +166,14 @@ extension LabsLoginController {
                 
                 if account.isStudent {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                        self.getAndSaveNotificationAndPrivacyPreferences()
+                        self.getAndSaveNotificationAndPrivacyPreferences {
+                            if UserDefaults.standard.getPreference(for: .collegeHouse) {
+                                CampusExpressNetworkManager.instance.updateHousingData()
+                            }
+                        }
                         self.getDiningBalance()
                         self.getDiningTransactions()
                         self.getAndSaveLaundryPreferences()
-                        CampusExpressNetworkManager.instance.updateHousingData()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             self.getCourses()
                         }
@@ -226,8 +229,10 @@ extension LabsLoginController {
         }
     }
     
-    fileprivate func getAndSaveNotificationAndPrivacyPreferences() {
-        UserDBManager.shared.syncUserSettings { (success) in }
+    fileprivate func getAndSaveNotificationAndPrivacyPreferences(_ completion: @escaping () -> Void) {
+        UserDBManager.shared.syncUserSettings { (success) in
+            completion()
+        }
     }
     
     fileprivate func obtainCoursePermission(_ callback: @escaping (_ granted: Bool) -> Void) {


### PR DESCRIPTION
This PR implements college house privacy permission. If permission is denied, all college house data is deleted from the server. Likewise, if permission is granted, the user's college house is retrieved from CampusExpress and saved.