### PR TITLE
Academic Profile Privacy-Permission

### DIFF
--- a/PennMobile/About/Privacy/PrivacyPreference.swift
+++ b/PennMobile/About/Privacy/PrivacyPreference.swift
@@ -133,6 +133,7 @@ extension PrivacyOption {
                 PennInTouchNetworkManager.instance.getDegrees { (degrees) in
                     if let degrees = degrees {
                         UserDBManager.shared.saveAcademicInfo(degrees)
+                        UserDefaults.standard.set(isInWharton: degrees.hasDegreeInWharton())
                     }
                 }
             default: break

--- a/PennMobile/About/Privacy/PrivacyPreference.swift
+++ b/PennMobile/About/Privacy/PrivacyPreference.swift
@@ -69,6 +69,13 @@ enum PrivacyOption: String, CaseIterable {
         }
     }
     
+    var requireAuth: Bool {
+        switch self {
+        case .academicIdentity: return true
+        default: return false
+        }
+    }
+    
     // MARK: User Defaults Keys
     // These keys ARE cleared when UserDefaults is wiped.
     
@@ -120,6 +127,12 @@ extension PrivacyOption {
                 CampusExpressNetworkManager.instance.updateHousingData { (success) in
                     UserDBManager.shared.saveMultiyearHousingData()
                 }
+            case .academicIdentity:
+                PennInTouchNetworkManager.instance.getDegrees { (degrees) in
+                    if let degrees = degrees {
+                        UserDBManager.shared.saveAcademicInfo(degrees)
+                    }
+                }
             default: break
             }
             
@@ -144,6 +157,8 @@ extension PrivacyOption {
                 UserDBManager.shared.deleteAnonymousCourses(completion)
             case .collegeHouse:
                 UserDBManager.shared.deleteHousingData(completion)
+            case .academicIdentity:
+                UserDBManager.shared.deleteAcademicInfo(completion)
             default: completion(true)
             }
         }

--- a/PennMobile/About/Privacy/PrivacyPreference.swift
+++ b/PennMobile/About/Privacy/PrivacyPreference.swift
@@ -69,9 +69,11 @@ enum PrivacyOption: String, CaseIterable {
         }
     }
     
-    var requireAuth: Bool {
+    var requiresAuth: Bool {
         switch self {
+        case .anonymizedCourseSchedule: return true
         case .academicIdentity: return true
+        case .collegeHouse: return true
         default: return false
         }
     }

--- a/PennMobile/About/Privacy/PrivacyTableViewController.swift
+++ b/PennMobile/About/Privacy/PrivacyTableViewController.swift
@@ -42,7 +42,7 @@ extension PrivacyViewController: PrivacyViewControllerChangedPreference {
             // This PrivacyOption requires authentication to give permission.
             if let lastLogin = UserDefaults.standard.getLastLogin(), lastLogin.minutesFrom(date: Date()) <= 10 {
                 // Don't ask user to login if it's been less than 10 minutes since last login
-                changePermission(option: option, givePermission: givePermission)
+                self.changePermission(option: option, givePermission: givePermission)
             } else {
                 let llc = LabsLoginController(fetchAllInfo: false, shouldRetrieveRefreshToken: false) { (success) in
                     if success {
@@ -53,7 +53,7 @@ extension PrivacyViewController: PrivacyViewControllerChangedPreference {
                 self.present(nvc, animated: true, completion: nil)
             }
         } else {
-            changePermission(option: option, givePermission: givePermission)
+            self.changePermission(option: option, givePermission: givePermission)
         }
     }
     

--- a/PennMobile/About/Privacy/PrivacyTableViewController.swift
+++ b/PennMobile/About/Privacy/PrivacyTableViewController.swift
@@ -38,29 +38,47 @@ class PrivacyViewController: GenericTableViewController, ShowsAlert, IndicatorEn
 // MARK: - Did Change Preference
 extension PrivacyViewController: PrivacyViewControllerChangedPreference {
     func changed(option: PrivacyOption, givePermission: Bool) {
+        if givePermission && option.requiresAuth {
+            // This PrivacyOption requires authentication to give permission.
+            if let lastLogin = UserDefaults.standard.getLastLogin(), lastLogin.minutesFrom(date: Date()) <= 10 {
+                // Don't ask user to login if it's been less than 10 minutes since last login
+                changePermission(option: option, givePermission: givePermission)
+            } else {
+                let llc = LabsLoginController(fetchAllInfo: false, shouldRetrieveRefreshToken: false) { (success) in
+                    if success {
+                        self.changePermission(option: option, givePermission: givePermission)
+                    }
+                }
+                let nvc = UINavigationController(rootViewController: llc)
+                self.present(nvc, animated: true, completion: nil)
+            }
+        } else {
+            changePermission(option: option, givePermission: givePermission)
+        }
+    }
+    
+    private func changePermission(option: PrivacyOption, givePermission: Bool) {
         self.showActivity()
         let deadline = DispatchTime.now() + 1
         if givePermission {
             option.givePermission { (success) in
-                DispatchQueue.main.asyncAfter(deadline: deadline) {
-                    self.hideActivity()
-                    if !success {
-                        self.showAlert(withMsg: "Could not save privacy preference. Please make sure you have an internet connection and try again.", title: "Error", completion: {
-                            self.tableView.reloadData()
-                        })
-                    }
-                }
+                self.onChangeCompletion(deadline: deadline, success: success)
             }
         } else {
             option.removePermission { (success) in
-                DispatchQueue.main.asyncAfter(deadline: deadline) {
-                    self.hideActivity()
-                    if !success {
-                        self.showAlert(withMsg: "Could not save privacy preference. Please make sure you have an internet connection and try again.", title: "Error", completion: {
-                            self.tableView.reloadData()
-                        })
-                    }
-                }
+                self.onChangeCompletion(deadline: deadline, success: success)
+            }
+        }
+    }
+    
+    /// Hides activity indicator after deadline has passed. If permision change was not successful, show alert.
+    private func onChangeCompletion(deadline: DispatchTime, success: Bool) {
+        DispatchQueue.main.asyncAfter(deadline: deadline) {
+            self.hideActivity()
+            if !success {
+                self.showAlert(withMsg: "Could not save privacy preference. Please make sure you have an internet connection and try again.", title: "Error", completion: {
+                    self.tableView.reloadData()
+                })
             }
         }
     }

--- a/PennMobile/Login/LabsLoginController.swift
+++ b/PennMobile/Login/LabsLoginController.swift
@@ -56,13 +56,15 @@ class LabsLoginController: PennLoginController, IndicatorEnabled, Requestable, S
     
     private var code: String?
     
+    private var shouldRetrieveRefreshToken = true
     private var shouldFetchAllInfo: Bool!
     private var completion: ((_ success: Bool) -> Void)!
     
-    convenience init(fetchAllInfo: Bool = true, completion: @escaping (_ success: Bool) -> Void) {
+    convenience init(fetchAllInfo: Bool = true, shouldRetrieveRefreshToken: Bool = true, completion: @escaping (_ success: Bool) -> Void) {
         self.init()
         self.completion = completion
         self.shouldFetchAllInfo = fetchAllInfo
+        self.shouldRetrieveRefreshToken = shouldRetrieveRefreshToken
     }
     
     convenience init(fetchAllInfo: Bool = true) {
@@ -80,6 +82,13 @@ class LabsLoginController: PennLoginController, IndicatorEnabled, Requestable, S
     }
     
     override func handleSuccessfulNavigation(_ webView: WKWebView, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard shouldRetrieveRefreshToken else {
+            // Refresh token does not to be retrieved. Dismiss controller immediately.
+            decisionHandler(.cancel)
+            self.dismiss(successful: true)
+            return
+        }
+        
         guard let code = code else {
             // Something went wrong, code not fetched
             decisionHandler(.cancel)
@@ -132,7 +141,7 @@ class LabsLoginController: PennLoginController, IndicatorEnabled, Requestable, S
             }
             UserDefaults.standard.storeCookies()
             self.hideActivity()
-            super.dismiss(animated: false, completion: nil)
+            super.dismiss(animated: true, completion: nil)
             self.completion(successful)
         }
     }


### PR DESCRIPTION
This PR implements academic profile privacy permission. If permission is denied, all academic profile data (school, year, etc.) is deleted from the server. Likewise, if permission is granted, the user's academic profile is retrieved and saved.

In addition, this PR contains login and privacy screen improvements. Namely, each PrivacyOption now  has a `requiresAuth` field, which if true, requires the user to sign-in with their PennKey before giving Penn Mobile permission to their data. Sign-in is never required when removing permission. Not only does this give greater security, it also ensures that 2FA is not required when accessing their information.