### PR TITLE
Pac code

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -195,6 +195,10 @@
 		C15C4B4E223EB16F00E443FD /* HomeReservationsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C4B4D223EB16F00E443FD /* HomeReservationsCell.swift */; };
 		C15C4B50223EB18800E443FD /* HomeReservationsCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C4B4F223EB18800E443FD /* HomeReservationsCellItem.swift */; };
 		C1D90F1D2220A25700DAB8EE /* NoReservationsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D90F1C2220A25700DAB8EE /* NoReservationsCell.swift */; };
+		C8C96F10241407000069D56A /* CourseScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C96F0E241407000069D56A /* CourseScheduleViewController.swift */; };
+		C8C96F11241407000069D56A /* CourseScheduleTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C96F0F241407000069D56A /* CourseScheduleTableViewModel.swift */; };
+		C8C96F15241407420069D56A /* PacCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C96F13241407420069D56A /* PacCodeViewController.swift */; };
+		C8C96F16241407420069D56A /* PacCodeNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C96F14241407420069D56A /* PacCodeNetworkManager.swift */; };
 		C94FC6D923996DBC8679AE9D /* Pods_AutomatedScreenshotUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1A2002DC69818BFD2427F92 /* Pods_AutomatedScreenshotUITests.framework */; };
 		CF1CE9BA205D5C3F00C51F46 /* MoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1CE9B9205D5C3F00C51F46 /* MoreViewController.swift */; };
 		CF1CE9BD205D664700C51F46 /* MoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1CE9BC205D664700C51F46 /* MoreCell.swift */; };
@@ -482,6 +486,10 @@
 		C15C4B4D223EB16F00E443FD /* HomeReservationsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeReservationsCell.swift; sourceTree = "<group>"; };
 		C15C4B4F223EB18800E443FD /* HomeReservationsCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeReservationsCellItem.swift; sourceTree = "<group>"; };
 		C1D90F1C2220A25700DAB8EE /* NoReservationsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoReservationsCell.swift; sourceTree = "<group>"; };
+		C8C96F0E241407000069D56A /* CourseScheduleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseScheduleViewController.swift; sourceTree = "<group>"; };
+		C8C96F0F241407000069D56A /* CourseScheduleTableViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseScheduleTableViewModel.swift; sourceTree = "<group>"; };
+		C8C96F13241407420069D56A /* PacCodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PacCodeViewController.swift; sourceTree = "<group>"; };
+		C8C96F14241407420069D56A /* PacCodeNetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PacCodeNetworkManager.swift; sourceTree = "<group>"; };
 		CF1CE9B9205D5C3F00C51F46 /* MoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreViewController.swift; sourceTree = "<group>"; };
 		CF1CE9BC205D664700C51F46 /* MoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreCell.swift; sourceTree = "<group>"; };
 		CF1CE9C0205D683400C51F46 /* HeaderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewCell.swift; sourceTree = "<group>"; };
@@ -1033,6 +1041,8 @@
 				21B653BD2246F338001A97C5 /* CoursesWebviewController.swift */,
 				21D5E07123BBFC5700B331CC /* CoursesNetworkManager.swift */,
 				21D5E07323BCFE0300B331CC /* CoursePrivacyController.swift */,
+				C8C96F0F241407000069D56A /* CourseScheduleTableViewModel.swift */,
+				C8C96F0E241407000069D56A /* CourseScheduleViewController.swift */,
 			);
 			path = Courses;
 			sourceTree = "<group>";
@@ -1307,9 +1317,19 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		C8C96F12241407320069D56A /* PAC Code */ = {
+			isa = PBXGroup;
+			children = (
+				C8C96F14241407420069D56A /* PacCodeNetworkManager.swift */,
+				C8C96F13241407420069D56A /* PacCodeViewController.swift */,
+			);
+			path = "PAC Code";
+			sourceTree = "<group>";
+		};
 		CF1CE9B8205D5BF100C51F46 /* More Tab */ = {
 			isa = PBXGroup;
 			children = (
+				C8C96F12241407320069D56A /* PAC Code */,
 				CF1CE9B9205D5C3F00C51F46 /* MoreViewController.swift */,
 				CF1CE9BC205D664700C51F46 /* MoreCell.swift */,
 				CF1CE9C0205D683400C51F46 /* HeaderViewCell.swift */,
@@ -1664,6 +1684,7 @@
 			files = (
 				EFE2D6F0239B11050020F6BF /* GroupSettingsCell.swift in Sources */,
 				B650C5681FA44C2100922E98 /* LaundryMachineCell.swift in Sources */,
+				C8C96F10241407000069D56A /* CourseScheduleViewController.swift in Sources */,
 				EFE2D6F5239B11050020F6BF /* GroupHeaderCell.swift in Sources */,
 				219F01F41FB7CCFA006BBC4E /* SAConfettiView.swift in Sources */,
 				219F01FB1FBE973A006BBC4E /* LaundryNotificationCenter.swift in Sources */,
@@ -1728,6 +1749,7 @@
 				2190FD3B1EC65E7800EC683C /* ContactManager.swift in Sources */,
 				21640D542010526B002F33CA /* HomeTableViewModel.swift in Sources */,
 				21640FD3204A296D008DB6E8 /* LaundryGraphView.swift in Sources */,
+				C8C96F11241407000069D56A /* CourseScheduleTableViewModel.swift in Sources */,
 				97E6E1F0239D74F500C07D7A /* GSRGroupIconView.swift in Sources */,
 				F212BE8423B6C8A200ED46A1 /* NotificationPreference.swift in Sources */,
 				21A6B6D022162652003A357D /* GSRReservationsController.swift in Sources */,
@@ -1750,6 +1772,7 @@
 				97AA806B23D26BC700C23488 /* DiningHeaderView.swift in Sources */,
 				2189C09F2027CE4100771C1F /* GSRUser.swift in Sources */,
 				2189C09D2027CE4100771C1F /* GSRLocationModel.swift in Sources */,
+				C8C96F15241407420069D56A /* PacCodeViewController.swift in Sources */,
 				B62875ED2115433100FB2873 /* PennCoordinate.swift in Sources */,
 				EFE2D6F6239B11050020F6BF /* GSRColorCell.swift in Sources */,
 				F212BE8823B71C7100ED46A1 /* NotificationsTableViewController.swift in Sources */,
@@ -1852,6 +1875,7 @@
 				667EC29623DB9C4800B0DF66 /* TwoFactorEnableController.swift in Sources */,
 				2196D5E31F5263AC002058A0 /* AnnouncementHeaderView.swift in Sources */,
 				97AA806A23D26BC700C23488 /* TransactionTableViewCell.swift in Sources */,
+				C8C96F16241407420069D56A /* PacCodeNetworkManager.swift in Sources */,
 				97E79E162100E33100D3D606 /* FitnessAPI.swift in Sources */,
 				21B556192224FDF700D80F61 /* SplashViewController.swift in Sources */,
 				B650C5641FA43FC600922E98 /* LaundryRoom.swift in Sources */,

--- a/PennMobile/Auth/PennAuthRequestable.swift
+++ b/PennMobile/Auth/PennAuthRequestable.swift
@@ -24,6 +24,12 @@ extension PennAuthRequestable {
         let url = URL(string: targetUrl)!
         let request = URLRequest(url: url)
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            
+            if let error = error, (error as NSError).code == -1009 {
+                completionHandler(nil, nil, NetworkingError.noInternet)
+                return
+            }
+            
             if let urlStr = response?.url?.absoluteString, urlStr == targetUrl {
                 UserDefaults.standard.setShibbolethAuth(authedIn: true)
                 completionHandler(data, response, error)
@@ -43,8 +49,7 @@ extension PennAuthRequestable {
                 }
             } else {
                 UserDefaults.standard.setShibbolethAuth(authedIn: false)
-//                completionHandler(nil, nil, NetworkingError.authenticationError)
-                completionHandler(nil, nil, NetworkingError.noInternet)
+                completionHandler(nil, nil, NetworkingError.other)
             }
             UserDefaults.standard.storeCookies()
         }

--- a/PennMobile/Auth/PennAuthRequestable.swift
+++ b/PennMobile/Auth/PennAuthRequestable.swift
@@ -43,7 +43,8 @@ extension PennAuthRequestable {
                 }
             } else {
                 UserDefaults.standard.setShibbolethAuth(authedIn: false)
-                completionHandler(nil, nil, NetworkingError.authenticationError)
+//                completionHandler(nil, nil, NetworkingError.authenticationError)
+                completionHandler(nil, nil, NetworkingError.noInternet)
             }
             UserDefaults.standard.storeCookies()
         }

--- a/PennMobile/Auth/PennLoginController.swift
+++ b/PennMobile/Auth/PennLoginController.swift
@@ -147,9 +147,11 @@ class PennLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate,
         }
     }
     
+    var handleCancel: (() -> Void)? = nil
+    
     @objc fileprivate func cancel(_ sender: Any) {
         _ = self.resignFirstResponder()
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: self.handleCancel)
     }
     
     // MARK: - Decide Policy Upon Completed Navigation

--- a/PennMobile/General/KeychainAccessible.swift
+++ b/PennMobile/General/KeychainAccessible.swift
@@ -19,6 +19,10 @@ extension KeychainAccessible {
         "PennKey Password"
     }
     
+    private var pacCodeKeychainKey: String {
+        "PAC Code"
+    }
+    
     func getPennKey() -> String? {
         let secureStore = getWebLoginSecureStore()
         do {
@@ -37,6 +41,15 @@ extension KeychainAccessible {
         }
     }
 
+    func getPacCode() -> String? {
+        let secureStore = getWebLoginSecureStore()
+        do {
+            return try secureStore.getValue(for: pacCodeKeychainKey)
+        } catch {
+            return nil
+        }
+    }
+
     func savePennKey(_ pennkey: String) {
         let secureStore = getWebLoginSecureStore()
         try? secureStore.setValue(pennkey, for: pennkeyKeychainKey)
@@ -45,6 +58,16 @@ extension KeychainAccessible {
     func savePassword(_ password: String) {
         let secureStore = getWebLoginSecureStore()
         try? secureStore.setValue(password, for: passwordKeychainKey)
+    }
+    
+    func savePacCode(_ pacCode: String) {
+        let secureStore = getWebLoginSecureStore()
+        try? secureStore.setValue(pacCode, for: pacCodeKeychainKey)
+    }
+    
+    func removePacCode() {
+        let secureStore = getWebLoginSecureStore()
+        try? secureStore.removeValue(for: pacCodeKeychainKey)
     }
     
     private func getWebLoginSecureStore() -> SecureStore {

--- a/PennMobile/General/Protocols.swift
+++ b/PennMobile/General/Protocols.swift
@@ -147,14 +147,14 @@ extension LocationPermissionRequestable {
     }
 }
 
-protocol LocalAuthentication {
+protocol LocallyAuthenticatable {
     func handleAuthenticationSuccess()
     func handleAuthenticationFailure()
 }
 
-extension LocalAuthentication {
+extension LocallyAuthenticatable {
     
-    func handleAuthentication(cancelText : String, reasonText: String) {
+    func requestAuthentication(cancelText : String, reasonText: String) {
         let context = LAContext()
         context.localizedCancelTitle = cancelText
 

--- a/PennMobile/General/Protocols.swift
+++ b/PennMobile/General/Protocols.swift
@@ -8,6 +8,7 @@
 
 import MBProgressHUD
 import CoreLocation
+import LocalAuthentication
 
 protocol IndicatorEnabled {}
 
@@ -142,6 +143,44 @@ extension LocationPermissionRequestable {
             }
         } else {
             return false
+        }
+    }
+}
+
+protocol LocalAuthentication {
+    func handleAuthenticationSuccess()
+    func handleAuthenticationFailure()
+}
+
+extension LocalAuthentication {
+    
+    func handleAuthentication(cancelText : String, reasonText: String) {
+        let context = LAContext()
+        context.localizedCancelTitle = cancelText
+
+        // Check if we have the needed hardware support.
+        var error: NSError?
+        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reasonText ) { success, error in
+
+                if success {
+                    // Move to the main thread because the user may request UI changes.
+                    DispatchQueue.main.async {
+                        self.handleAuthenticationSuccess()
+                    }
+
+                } else {
+                    // Failed to authenticate with FaceID/passcode
+                    DispatchQueue.main.async {
+                        self.handleAuthenticationFailure()
+                    }
+                }
+            }
+        } else {
+            // Can't evaluate policy
+            DispatchQueue.main.async {
+                self.handleAuthenticationFailure()
+            }
         }
     }
 }

--- a/PennMobile/Login/LabsLoginController.swift
+++ b/PennMobile/Login/LabsLoginController.swift
@@ -256,9 +256,12 @@ extension LabsLoginController {
     }
     
     fileprivate func getPacCode() {
-        PacCodeNetworkManager.instance.getPacCode { pacCode in
-            if let pacCode = pacCode {
+        PacCodeNetworkManager.instance.getPacCode { result in
+            switch result {
+            case .success(let pacCode):
                 self.savePacCode(pacCode)
+            case .failure(_):
+                return
             }
         }
     }

--- a/PennMobile/Login/LabsLoginController.swift
+++ b/PennMobile/Login/LabsLoginController.swift
@@ -199,6 +199,7 @@ extension LabsLoginController {
                         self.getDiningBalance()
                         self.getDiningTransactions()
                         self.getAndSaveLaundryPreferences()
+                        self.getPacCode()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             self.getCourses()
                         }
@@ -250,6 +251,14 @@ extension LabsLoginController {
         UserDBManager.shared.getLaundryPreferences { rooms in
             if let rooms = rooms {
                 UserDefaults.standard.setLaundryPreferences(to: rooms)
+            }
+        }
+    }
+    
+    fileprivate func getPacCode() {
+        PacCodeNetworkManager.instance.getPacCode { pacCode in
+            if let pacCode = pacCode {
+                self.savePacCode(pacCode)
             }
         }
     }

--- a/PennMobile/New Group/PAC Code/PacCodeNetworkManager.swift
+++ b/PennMobile/New Group/PAC Code/PacCodeNetworkManager.swift
@@ -39,7 +39,6 @@ extension PacCodeNetworkManager: PennAuthRequestable {
                 let pacCode = try self.findPacCode(from: html as String)
                 return callback(.success(pacCode))
             } catch {
-                print("parsing error")
                 return callback(.failure(.parsingError))
             }
         }
@@ -66,9 +65,8 @@ extension PacCodeNetworkManager: PennAuthRequestable {
         }
         
         
+        // PAC Code is stored in the 5th index of the array
         if (identity.count == 6) {
-            
-            // PAC Code is stored in the 5th index of the array
             return identity[5]
         } else {
             throw NetworkingError.parsingError

--- a/PennMobile/New Group/PAC Code/PacCodeNetworkManager.swift
+++ b/PennMobile/New Group/PAC Code/PacCodeNetworkManager.swift
@@ -1,0 +1,71 @@
+//
+//  PacCodeNetworkManager.swift
+//  PennMobile
+//
+//  Created by CHOI Jongmin on 1/3/2020.
+//  Copyright © 2020 PennLabs. All rights reserved.
+//
+
+import SwiftSoup
+
+class PacCodeNetworkManager {
+    static let instance = PacCodeNetworkManager()
+    private init() {}
+}
+
+extension PacCodeNetworkManager: PennAuthRequestable {
+
+    private var pacURL: String {
+        return "https://penncard.apps.upenn.edu/penncard/jsp/fast2.do?fastStart=pacExpress"
+    }
+    
+    private var shibbolethUrl: String {
+        return "https://penncard.apps.upenn.edu/penncard/jsp/fast2.do/Shibboleth.sso/SAML2/POST"
+    }
+    
+    func getPacCode(callback: @escaping ((_ code: String?) -> Void)) {
+        makeAuthRequest(targetUrl: pacURL, shibbolethUrl: shibbolethUrl) { (data, response, error) in
+            if let httpResponse = response as? HTTPURLResponse {
+                if httpResponse.statusCode == 200 {
+                    if let data = data, let html = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String? {
+                        do {
+                            let pacCode = try self.findPacCode(from: html)
+                            return callback(pacCode)
+                        } catch {
+                            return callback(nil)
+                        }
+                    }
+                }
+            } else {
+                return callback(nil)
+            }
+        }
+    }
+    
+    private func findPacCode(from html: String) throws -> String {
+        let doc: Document = try SwiftSoup.parse(html)
+        guard let element: Element = try doc.getElementsByClass("msgbody").first() else {
+            throw NetworkingError.parsingError
+        }
+        
+        // Stores ["Name", name in caps, "PennId", Penn ID, "Current PAC", PAC Code]
+        var identity = [String]()
+        
+        do {
+            for row in try element.select("tr") {
+                for col in try row.select("td") {
+                    let colContent = try col.text()
+                    identity.append(colContent)
+                }
+            }
+        } catch {
+            throw NetworkingError.parsingError
+        }
+        
+        // PAC Code is stored in the 5th index of the array
+        return identity[5]
+    }
+    
+    
+    
+}

--- a/PennMobile/New Group/PAC Code/PacCodeViewController.swift
+++ b/PennMobile/New Group/PAC Code/PacCodeViewController.swift
@@ -15,6 +15,7 @@ class PacCodeViewController : UIViewController, ShowsAlert, IndicatorEnabled {
     lazy var quadDigitLabel = [digitLabel, digitLabel, digitLabel, digitLabel]
     
     let pacCodeHStack = UIStackView()
+    let pacCodeSecurityInfoLabel = UILabel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,7 +27,9 @@ class PacCodeViewController : UIViewController, ShowsAlert, IndicatorEnabled {
         self.navigationItem.rightBarButtonItem = .init(barButtonSystemItem: .refresh, target: self, action: #selector(refreshButtonTapped))
         
         setupPacCodeHStack()
-        setupPacCodeInfoLabel()
+        setupPacCodeSecurityInfoLabel()
+        setupPacCodeTitleLabel()
+        setupPlaceHolderIcon()
     }
     
     var digitLabel : UILabel {
@@ -58,22 +61,59 @@ class PacCodeViewController : UIViewController, ShowsAlert, IndicatorEnabled {
         pacCodeHStack.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
     }
     
-    func setupPacCodeInfoLabel() {
-        let pacCodeInfoLabel = UILabel()
-        pacCodeInfoLabel.textColor = .labelPrimary
-        pacCodeInfoLabel.font = UIFont.systemFont(ofSize: 35)
-        pacCodeInfoLabel.text = "Your PAC Code is"
+    func setupPacCodeSecurityInfoLabel() {
+        pacCodeSecurityInfoLabel.textColor = .labelSecondary
+        pacCodeSecurityInfoLabel.font = UIFont.systemFont(ofSize: 16)
+        pacCodeSecurityInfoLabel.text = "After being fetched from Campus Express, your PAC code is stored in your device’s Secure Enclave.\n\nIt requires your authentication to view each time and never leaves your device."
         
-        view.addSubview(pacCodeInfoLabel)
-        pacCodeInfoLabel.translatesAutoresizingMaskIntoConstraints = false
-        pacCodeInfoLabel.bottomAnchor.constraint(equalTo: pacCodeHStack.topAnchor, constant: -30).isActive = true
-        pacCodeInfoLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
+        pacCodeSecurityInfoLabel.numberOfLines = 0
+        pacCodeSecurityInfoLabel.textAlignment = .center
+        
+        
+        view.addSubview(pacCodeSecurityInfoLabel)
+        pacCodeSecurityInfoLabel.translatesAutoresizingMaskIntoConstraints = false
+        pacCodeSecurityInfoLabel.bottomAnchor.constraint(equalTo: pacCodeHStack.topAnchor, constant: -25).isActive = true
+        pacCodeSecurityInfoLabel.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.80).isActive = true
+        pacCodeSecurityInfoLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
+    }
+    
+    func setupPacCodeTitleLabel() {
+        let pacCodeTitleLabel = UILabel()
+        pacCodeTitleLabel.textColor = .labelPrimary
+        pacCodeTitleLabel.font = UIFont.systemFont(ofSize: 35)
+        pacCodeTitleLabel.text = "PAC Code"
+        
+        view.addSubview(pacCodeTitleLabel)
+        pacCodeTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        pacCodeTitleLabel.bottomAnchor.constraint(equalTo: pacCodeSecurityInfoLabel.topAnchor, constant: -20).isActive = true
+        pacCodeTitleLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
+    }
+    
+//    This is only in place as a placeholder for an icon if deemed necessary
+    func setupPlaceHolderIcon() {
+        if #available(iOS 13.0, *) {
+            let placeHolderIcon = UIImageView(image: UIImage(systemName: "circle.grid.3x3.fill"))
+            view.addSubview(placeHolderIcon)
+            
+            placeHolderIcon.translatesAutoresizingMaskIntoConstraints = false
+            placeHolderIcon.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40).isActive = true
+            placeHolderIcon.tintColor = .grey1
+            placeHolderIcon.widthAnchor.constraint(equalToConstant: 100).isActive = true
+            placeHolderIcon.heightAnchor.constraint(equalToConstant: 100).isActive = true
+            placeHolderIcon.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
+        }
     }
     
     func updatePACCode() {
         if let pacCode = pacCode {
+            let pacCodefadeInAnimation: CATransition = CATransition()
+            pacCodefadeInAnimation.duration = 0.5
+            pacCodefadeInAnimation.type = CATransitionType.fade
+            pacCodefadeInAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+            
             var counter = 0
             for pacCodeDigit in pacCode {
+                quadDigitLabel[counter].layer.add(pacCodefadeInAnimation, forKey: "changeTextTransition")
                 quadDigitLabel[counter].text = "\(pacCodeDigit)"
                 counter += 1
             }
@@ -103,38 +143,32 @@ extension PacCodeViewController : KeychainAccessible, LocallyAuthenticatable {
     func handleAuthenticationSuccess() {
         if let pacCode = getPacCode() {
             self.pacCode = pacCode
+            updatePACCode()
         } else {
             if Account.isLoggedIn {
-                self.showActivity()
-                
                 // Handle the case in which the user is logged in but hasn't yet fetched their PAC Codes
-                // Acts as though the user pressed the refresh button
-                PacCodeNetworkManager.instance.getPacCode { result in self.handleNetworkPacCodeRefreshCompletion(result) }
+                handleNetworkPacCodeRefetch()
             } else {
                 self.showAlert(withMsg: "Please login to use this feature", title: "Login Error", completion: { self.navigationController?.popViewController(animated: true)} )
             }
         }
-        
-        updatePACCode()
     }
     
     func handleAuthenticationFailure() {
         self.navigationController?.popViewController(animated: true)
     }
-        
 }
 
 // MARK: - PAC Code Refreshing
 extension PacCodeViewController {
     @objc func refreshButtonTapped() {
-        let message = "Has there been a change to your PAC Code? Would you like Penn Mobile to update your information?"
-        let alert = UIAlertController(title: "Update PAC Code", message: message, preferredStyle: .alert)
+        let message = "Has there been a change to your PAC Code? Would you like Penn Mobile to refresh your information?"
+        let alert = UIAlertController(title: "Refresh PAC Code", message: message, preferredStyle: .alert)
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         
         let refreshPacCode = UIAlertAction(title: "Yes", style: .default, handler: { (UIAlertAction) in
-            self.showActivity()
-            PacCodeNetworkManager.instance.getPacCode { result in self.handleNetworkPacCodeRefreshCompletion(result) }
+            self.handleNetworkPacCodeRefetch()
         })
         
         alert.addAction(refreshPacCode)
@@ -143,39 +177,45 @@ extension PacCodeViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    fileprivate func handleNetworkPacCodeRefreshCompletion(_ result: Result<String, NetworkingError>) {
-        DispatchQueue.main.async {
-            self.hideActivity()
-            
-            switch result {
-            case .success(let pacCode):
-                self.savePacCode(pacCode)
-                self.pacCode = pacCode
-                self.showAlert(withMsg: "Your PAC Code has been updated.", title: "Success!", completion: self.updatePACCode)
-                
-            case .failure(.noInternet):
-                self.showAlert(withMsg: "You appear to be offline.\nPlease try again later.", title: "Network Error", completion: { self.navigationController?.popViewController(animated: true) })
-                
-            case .failure(.parsingError):
-                self.showAlert(withMsg: "Penn's PAC Code servers are currently not updating.We hope this will be fixed shortly", title: "Uh oh!", completion: { self.navigationController?.popViewController(animated: true) })
-                
-            case .failure(.authenticationError):
-                self.showAlert(withMsg: "Unable to access your PAC Code.\nPlease login again.", title: "Login Error", completion: { self.handleAuthenticationError() })
-                
-            default:
-                self.showAlert(withMsg: "Something went wrong.\nPlease try again later.", title: "Uh oh!", completion: { self.navigationController?.popViewController(animated: true) } )
+    fileprivate func handleNetworkPacCodeRefetch() {
+        self.showActivity()
+        PacCodeNetworkManager.instance.getPacCode { result in
+            DispatchQueue.main.async {
+                self.handleNetworkPacCodeResult(result)
+                self.hideActivity()
             }
         }
     }
     
+    fileprivate func handleNetworkPacCodeResult(_ result: Result<String, NetworkingError>) {
+        switch result {
+        case .success(let pacCode):
+            self.savePacCode(pacCode)
+            self.pacCode = pacCode
+            self.showAlert(withMsg: "Your PAC Code has been refreshed.", title: "Refresh Complete!", completion: self.updatePACCode)
+            
+        case .failure(.noInternet):
+            self.showAlert(withMsg: "You appear to be offline.\nPlease try again later.", title: "Network Error", completion: { self.navigationController?.popViewController(animated: true) })
+            
+        case .failure(.parsingError):
+            self.showAlert(withMsg: "Penn's PAC Code servers are currently not updating. We hope this will be fixed shortly", title: "Uh oh!", completion: { self.navigationController?.popViewController(animated: true) })
+            
+        case .failure(.authenticationError):
+            self.showAlert(withMsg: "Unable to access your PAC Code.\nPlease login again.", title: "Login Error", completion: { self.handleAuthenticationError() })
+            
+        default:
+            self.showAlert(withMsg: "Something went wrong.\nPlease try again later.", title: "Uh oh!", completion: { self.navigationController?.popViewController(animated: true) } )
+        }
+    }
+    
     fileprivate func handleAuthenticationError() {
-        
         let llc = LabsLoginController { (success) in
             DispatchQueue.main.async {
-                print("success")
                 self.loginCompletion(success)
             }
         }
+        
+        llc.handleCancel = { self.navigationController?.popViewController(animated: true) }
         
         let nvc = UINavigationController(rootViewController: llc)
         
@@ -184,8 +224,7 @@ extension PacCodeViewController {
     
     fileprivate func loginCompletion(_ successful: Bool) {
         if successful {
-            self.showActivity()
-            PacCodeNetworkManager.instance.getPacCode { result in self.handleNetworkPacCodeRefreshCompletion(result) }
+            handleNetworkPacCodeRefetch()
         } else {
             showAlert(withMsg: "Something went wrong. Please try again later.", title: "Uh oh!", completion: { self.navigationController?.popViewController(animated: true) } )
         }

--- a/PennMobile/New Group/PAC Code/PacCodeViewController.swift
+++ b/PennMobile/New Group/PAC Code/PacCodeViewController.swift
@@ -104,8 +104,6 @@ extension PacCodeViewController : LocalAuthentication {
         if let pacCode = getPacCode() {
             self.pacCode = pacCode
         } else {
-            PacCodeNetworkManager.instance.getPacCode(callback: savePacCode(_:))
-
             self.showAlert(withMsg: "Please login to use this feature", title: "Login Error", completion: { self.navigationController?.popViewController(animated: true)} )
         }
         
@@ -149,6 +147,4 @@ extension PacCodeViewController {
             }
         }
     }
-//    fileprivate func fetch
-    
 }

--- a/PennMobile/New Group/PAC Code/PacCodeViewController.swift
+++ b/PennMobile/New Group/PAC Code/PacCodeViewController.swift
@@ -1,0 +1,154 @@
+//
+//  PacCodeViewController.swift
+//  PennMobile
+//
+//  Created by CHOI Jongmin on 5/3/2020.
+//  Copyright © 2020 PennLabs. All rights reserved.
+//
+
+import Foundation
+
+class PacCodeViewController : UIViewController, KeychainAccessible, ShowsAlert, IndicatorEnabled {
+    
+    var pacCode : String?
+        
+    lazy var quadDigitLabel = [digitLabel, digitLabel, digitLabel, digitLabel]
+    
+    let pacCodeHStack = UIStackView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        
+        self.title = "PAC Code"
+        
+        self.navigationItem.rightBarButtonItem = .init(barButtonSystemItem: .refresh, target: self, action: #selector(refreshButtonTapped))
+        
+        setupPacCodeHStack()
+        setupPacCodeInfoLabel()
+    }
+    
+    var digitLabel : UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.heightAnchor.constraint(equalToConstant: 70).isActive = true
+        label.widthAnchor.constraint(equalToConstant: 70).isActive = true
+        
+        label.textAlignment = .center
+        label.font = UIFont.boldSystemFont(ofSize: 30)
+        
+        label.backgroundColor = .grey6
+        
+        return label
+    }
+
+    func setupPacCodeHStack() {
+        pacCodeHStack.axis = .horizontal
+        pacCodeHStack.distribution = .equalCentering
+        pacCodeHStack.spacing = 10.0
+        
+        for digitLabel in quadDigitLabel {
+            pacCodeHStack.addArrangedSubview(digitLabel)
+        }
+        
+        view.addSubview(pacCodeHStack)
+        pacCodeHStack.translatesAutoresizingMaskIntoConstraints = false
+        pacCodeHStack.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor).isActive = true
+        pacCodeHStack.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
+    }
+    
+    func setupPacCodeInfoLabel() {
+        let pacCodeInfoLabel = UILabel()
+        pacCodeInfoLabel.textColor = .labelPrimary
+        pacCodeInfoLabel.font = UIFont.systemFont(ofSize: 35)
+        pacCodeInfoLabel.text = "Your PAC Code is"
+        
+        view.addSubview(pacCodeInfoLabel)
+        pacCodeInfoLabel.translatesAutoresizingMaskIntoConstraints = false
+        pacCodeInfoLabel.bottomAnchor.constraint(equalTo: pacCodeHStack.topAnchor, constant: -30).isActive = true
+        pacCodeInfoLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor).isActive = true
+    }
+    
+    func refreshPacCode() {
+        if let pacCode = pacCode {
+            var counter = 0
+            for pacCodeDigit in pacCode {
+                quadDigitLabel[counter].text = "\(pacCodeDigit)"
+                counter += 1
+            }
+        } else {
+            for box in quadDigitLabel {
+                box.text = ""
+            }
+        }
+    }
+}
+
+// MARK: - Local Authentication
+extension PacCodeViewController : LocalAuthentication {
+        
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        handleAuthentication(cancelText: "Go Back", reasonText: "Authenticate to see your PAC Code")
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        pacCode = nil
+        refreshPacCode()
+    }
+    
+    func handleAuthenticationSuccess() {
+        if let pacCode = getPacCode() {
+            self.pacCode = pacCode
+        } else {
+            PacCodeNetworkManager.instance.getPacCode(callback: savePacCode(_:))
+
+            self.showAlert(withMsg: "Please login to use this feature", title: "Login Error", completion: { self.navigationController?.popViewController(animated: true)} )
+        }
+        
+        refreshPacCode()
+    }
+    
+    func handleAuthenticationFailure() {
+        self.navigationController?.popViewController(animated: true)
+    }
+        
+}
+
+// MARK: - PAC Code Refreshing
+extension PacCodeViewController {
+    @objc func refreshButtonTapped() {
+        let message = "Has there been a change to your PAC Code? Would you like Penn Mobile to update your information?"
+        let alert = UIAlertController(title: "Update PAC Code", message: message, preferredStyle: .alert)
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        
+        let refreshPacCode = UIAlertAction(title: "Yes", style: .default, handler: { (UIAlertAction) in
+            self.showActivity()
+            PacCodeNetworkManager.instance.getPacCode(callback: self.handleNetworkPacCodeRefreshCompletion(_:))
+        })
+        
+        alert.addAction(refreshPacCode)
+        alert.addAction(cancelAction)
+        
+        present(alert, animated: true, completion: nil)
+    }
+    
+    fileprivate func handleNetworkPacCodeRefreshCompletion(_ pacCode: String?) {
+        DispatchQueue.main.async {
+            self.hideActivity()
+            if let pacCode = pacCode {
+                self.savePacCode(pacCode)
+                self.pacCode = pacCode
+                self.showAlert(withMsg: "Your PAC Code has been updated.", title: "Success!", completion: self.refreshPacCode)
+            } else {
+                self.showAlert(withMsg: "Unable to access your courses. Please try again later.", title: "Uh oh!", completion: nil)
+            }
+        }
+    }
+//    fileprivate func fetch
+    
+}

--- a/PennMobile/Setup + Navigation/ControllerModel.swift
+++ b/PennMobile/Setup + Navigation/ControllerModel.swift
@@ -28,6 +28,7 @@ enum Feature: String {
     case privacy = "Privacy"
     case notifications = "Notifications"
     case courseSchedule = "Course Schedule"
+    case pacCode = "PAC Code"
 }
 
 class ControllerModel: NSObject {
@@ -51,6 +52,7 @@ class ControllerModel: NSObject {
         vcDictionary[.notifications] = NotificationViewController()
         vcDictionary[.privacy] = PrivacyViewController()
         vcDictionary[.courseSchedule] = CourseScheduleViewController()
+        vcDictionary[.pacCode] = PacCodeViewController()
 //        vcDictionary[.fling] = FlingViewController()
     }
 

--- a/PennMobile/Supporting_Files/Info.plist
+++ b/PennMobile/Supporting_Files/Info.plist
@@ -47,6 +47,8 @@
 	<string>Contacts access is required to add emergency contacts</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Enable to show your current location on the map</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Use Face ID instead of a password for authentication</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Enable users to view their PAC Code if they are logged in. 
Users can enable FaceID to authenticate themselves the first time they access PAC code data
Requires authentication using biometrics each time they access the data.
Has a refresh button on the top right screen to refetch PAC Code data.
Stores PAC Code data in the user's keychain, and removes it when the user intentionally/unintentionally logs out. 

Throws an alert if user attempt to access PAC Code without logging in.

For security reasons, I subtracted a random 4 digit number from my PAC Code when taking the screen shots below.

Created a "LocalAuthentication" protocol that enables users to use biometrics/password to access specific information

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-07 at 10 26 20](https://user-images.githubusercontent.com/49562117/76149905-9de83300-6072-11ea-9c24-8fe577b82a0c.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-07 at 10 26 26](https://user-images.githubusercontent.com/49562117/76149960-35e61c80-6073-11ea-9066-a6f0a4152344.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-07 at 10 26 31](https://user-images.githubusercontent.com/49562117/76149965-40a0b180-6073-11ea-8bb9-36df75bf8e4b.png)


![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-07 at 10 26 41](https://user-images.githubusercontent.com/49562117/76149972-5dd58000-6073-11ea-9ccb-dc7f3213e965.png)