### PR TITLE
PAC code display bug fix initial commit

### DIFF
--- a/PennMobile/New Group/PAC Code/PacCodeViewController.swift
+++ b/PennMobile/New Group/PAC Code/PacCodeViewController.swift
@@ -141,16 +141,16 @@ extension PacCodeViewController : KeychainAccessible, LocallyAuthenticatable {
     }
     
     func handleAuthenticationSuccess() {
-        if let pacCode = getPacCode() {
-            self.pacCode = pacCode
-            updatePACCode()
-        } else {
-            if Account.isLoggedIn {
+        if Account.isLoggedIn {
+            if let pacCode = getPacCode() {
+                self.pacCode = pacCode
+                updatePACCode()
+            } else {
                 // Handle the case in which the user is logged in but hasn't yet fetched their PAC Codes
                 handleNetworkPacCodeRefetch()
-            } else {
-                self.showAlert(withMsg: "Please login to use this feature", title: "Login Error", completion: { self.navigationController?.popViewController(animated: true)} )
             }
+        } else {
+            self.showAlert(withMsg: "Please login to use this feature", title: "Login Error", completion: { self.navigationController?.popViewController(animated: true)} )
         }
     }
     


### PR DESCRIPTION
The issue was that the code before was checking the validity of the request in the following order
1. Check if the PAC code existed in the user's secure enclave
2. If not, check if a user was logged in

When a user logged out, it would automatically clear the secure enclave of this information. I initially thought this would be sufficient to prevent cases of displaying the PAC code when logged out. This however was not fool-proof as if the users deleted their app while being logged in, the PAC code stored in their secured enclave will persist. When the app was redownloaded, users could access the PAC code without being logging in at all.

This pull request, reversing this order of checks. This ensures that the PAC code displays only in the condition in which the user is logged in. Even if the user does delete the app while being logged in, the PAC code will exist in the secure enclave (which users do not have direct access to), re-logging and clicking on the PAC code row will cause this data to be overwritten, hence handling the case in which a new account logs in on the same device.