### PR TITLE
Homescreen non-interactive bugfix

### DIFF
--- a/PennMobile/General/ModularTableView/ModularTableViewModel.swift
+++ b/PennMobile/General/ModularTableView/ModularTableViewModel.swift
@@ -27,6 +27,7 @@ extension ModularTableViewModel: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as! ModularTableViewCell
         cell.item = item
         cell.delegate = self.delegate
+        (cell as! UITableViewCell).contentView.isUserInteractionEnabled = false 
         return cell as! UITableViewCell
     }
 }


### PR DESCRIPTION
The issue was that UITableViewCells have a contentView. This was placed in front of the various views in our own custom table view cells and blocked touches to any views behind it. 

Setting the isUserInteractionEnabled of contentView to false has allowed us to re-enable the various touch detection that was necessary for our homescreen.