### PR TITLE
Improve More tab typography with system fonts

### DIFF
--- a/PennMobile/More Tab/HeaderViewCell.swift
+++ b/PennMobile/More Tab/HeaderViewCell.swift
@@ -13,7 +13,7 @@ class HeaderViewCell: UITableViewCell {
     var headerLabel: UILabel = {
         let headerLabel = UILabel()
         headerLabel.textColor = .labelSecondary
-        headerLabel.font = UIFont(name: "HelveticaNeue-Bold", size: 16)
+        headerLabel.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 17, weight: .bold))
         return headerLabel
     }()
 

--- a/PennMobile/More Tab/MoreCell.swift
+++ b/PennMobile/More Tab/MoreCell.swift
@@ -13,7 +13,7 @@ class MoreCell: UITableViewCell {
     var titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .labelPrimary
-        label.font = UIFont(name: "HelveticaNeue-Light", size: 19)
+        label.font = UIFont.preferredFont(forTextStyle: .body)
         return label
     }()
 
@@ -36,7 +36,8 @@ class MoreCell: UITableViewCell {
         titleLabel.text = page.rawValue
         self.addSubview(iconImage)
         self.addSubview(titleLabel)
-        _ = iconImage.anchor(self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: nil, topConstant: 10, leftConstant: 15, bottomConstant: 10, rightConstant: 0, widthConstant: 30, heightConstant: 0)
+        iconImage.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+        _ = iconImage.anchor(left: self.leftAnchor, leftConstant: 15, widthConstant: 30, heightConstant: 30)
         _ = titleLabel.anchor(self.topAnchor, left: iconImage.rightAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, topConstant: 12, leftConstant: 10, bottomConstant: 12, rightConstant: 0, widthConstant: 0, heightConstant: 0)
     }
 

--- a/PennMobile/More Tab/MoreViewController.swift
+++ b/PennMobile/More Tab/MoreViewController.swift
@@ -61,6 +61,8 @@ class MoreViewController: GenericTableViewController, ShowsAlert {
         tableView.dataSource = self
         tableView.backgroundColor = UIColor.uiGroupedBackground
         tableView.separatorStyle = .singleLine
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 50
         tableView.register(MoreCell.self, forCellReuseIdentifier: "more")
         tableView.register(MoreCell.self, forCellReuseIdentifier: "more-with-icon")
         tableView.tableFooterView = UIView()
@@ -140,14 +142,6 @@ extension MoreViewController {
             }
         }
         return UITableViewCell()
-    }
-
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 50
-    }
-
-    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 50
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
A quick design adjustment since this has been bothering me since I downloaded the Penn Mobile app.

Before:
![IMG_0296](https://user-images.githubusercontent.com/7005789/193478349-06f2ca1a-a4e1-473f-bff8-dd73ab25f3fb.PNG)

After:
![IMG_0295](https://user-images.githubusercontent.com/7005789/193478357-a993776a-ac1a-49a0-b64c-7b4724f173cd.PNG)

As a side benefit, the More tab now responds to the system text size setting:
![IMG_0297](https://user-images.githubusercontent.com/7005789/193478386-11583a33-b46a-42c3-b5f6-fe114968acbf.PNG)

Relevant discussion: https://penn-labs.slack.com/archives/C77NJGABD/p1664748125747129

Feel free to discuss whether this is even needed in the first place.