### PR TITLE
Fixed dining analytics bugs (now predicts from maximum balance)

### DIFF
--- a/PennMobile/Dining/Model/DiningVenue.swift
+++ b/PennMobile/Dining/Model/DiningVenue.swift
@@ -10,6 +10,21 @@ import Foundation
 
 struct DiningVenue: Codable, Equatable, Identifiable {
     static let directory = "diningVenue-v2.json"
+    static let menuUrlDict: [Int: String] = [593: "https://university-of-pennsylvania.cafebonappetit.com/cafe/1920-commons/",
+                                           636: "https://university-of-pennsylvania.cafebonappetit.com/cafe/hill-house/",
+                                           637: "https://university-of-pennsylvania.cafebonappetit.com/cafe/kings-court-english-house/",
+                                           638: "https://university-of-pennsylvania.cafebonappetit.com/cafe/falk-dining-commons/",
+                                           747: "https://university-of-pennsylvania.cafebonappetit.com/cafe/mcclelland/",
+                                           1442: "https://university-of-pennsylvania.cafebonappetit.com/cafe/lauder-college-house/",
+                                           639: "https://university-of-pennsylvania.cafebonappetit.com/cafe/houston-market/",
+                                           641: "https://university-of-pennsylvania.cafebonappetit.com/cafe/accenture-cafe/",
+                                           642: "https://university-of-pennsylvania.cafebonappetit.com/cafe/joes-cafe/",
+                                           1057: "https://university-of-pennsylvania.cafebonappetit.com/cafe/1920-gourmet-grocer/",
+                                           1163: "https://university-of-pennsylvania.cafebonappetit.com/cafe/1920-starbucks/",
+                                           1732: "https://university-of-pennsylvania.cafebonappetit.com/cafe/pret-a-manger-upper/",
+                                           1733: "https://university-of-pennsylvania.cafebonappetit.com/cafe/pret-a-manger-lower/",
+                                           1464004: "https://university-of-pennsylvania.cafebonappetit.com/cafe/quaker-kitchen/",
+                                           1464009: "https://university-of-pennsylvania.cafebonappetit.com/cafe/cafe-west/"]
 
     let id: Int
     let name: String

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
@@ -46,11 +46,11 @@ struct DiningAnalyticsView: View {
                     .bold()
                 if Account.isLoggedIn, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration {
                     CardView {
-                        PredictionsGraphView(type: "dollars", data: dollarXYHistory, predictedZeroDate: $diningAnalyticsViewModel.dollarPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedDollarSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.dollarAxisLabel, predictedZeroPoint: $diningAnalyticsViewModel.predictedDollarZeroPoint)
+                        PredictionsGraphView(type: "dollars", data: dollarXYHistory, predictedZeroDate: $diningAnalyticsViewModel.dollarPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedDollarSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.dollarAxisLabel, slope: $diningAnalyticsViewModel.dollarSlope)
                     }
                     CardView {
                         PredictionsGraphView(type: "swipes", data:
-                                                swipeXYHistory, predictedZeroDate: $diningAnalyticsViewModel.swipesPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedSwipesSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.swipeAxisLabel, predictedZeroPoint: $diningAnalyticsViewModel.predictedSwipesZeroPoint)
+                                                swipeXYHistory, predictedZeroDate: $diningAnalyticsViewModel.swipesPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedSwipesSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.swipeAxisLabel, slope: $diningAnalyticsViewModel.swipeSlope)
                     }
                     Spacer()
                 }

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/PredictionsGraphView+SmoothedData.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/PredictionsGraphView+SmoothedData.swift
@@ -27,17 +27,4 @@ extension PredictionsGraphView {
         return yxPoints
     }
 
-    static func getPredictionZeroPoint(startOfSemester sos: Date, endOfSemester eos: Date, predictedZeroDate zpd: Date) -> PredictionsGraphView.YXDataPoint {
-
-        guard sos < eos else { return .init(y: 0.0, x: 0.0) }
-
-        let fullSemester = sos.distance(to: eos)
-        let fullZeroDistance = sos.distance(to: zpd)
-
-        // x value, may be > 1 if the zero date is past end of semester
-        let x = (fullZeroDistance / fullSemester)
-
-        // y value is always zero
-        return .init(y: 0.0, x: CGFloat(x))
-    }
 }

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/PredictionsGraphView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/PredictionsGraphView.swift
@@ -15,7 +15,7 @@ struct PredictionsGraphView: View {
     @Binding var predictedZeroDate: Date
     @Binding var predictedSemesterEndValue: Double
     @Binding var axisLabelsYX: ([String], [String])
-    @Binding var predictedZeroPoint: YXDataPoint
+    @Binding var slope: Double
 
     enum BalanceType {
         case swipes
@@ -27,12 +27,12 @@ struct PredictionsGraphView: View {
 
     var formattedZeroDate: String
     var displayZeroDate: Bool
-    init(type: String, data: Binding<[PredictionsGraphView.YXDataPoint]>, predictedZeroDate: Binding<Date>, predictedSemesterEndValue: Binding<Double>, axisLabelsYX: Binding<([String], [String])>, predictedZeroPoint: Binding<PredictionsGraphView.YXDataPoint>) {
+    init(type: String, data: Binding<[PredictionsGraphView.YXDataPoint]>, predictedZeroDate: Binding<Date>, predictedSemesterEndValue: Binding<Double>, axisLabelsYX: Binding<([String], [String])>, slope: Binding<Double>) {
         self._data = data
         self._predictedZeroDate = predictedZeroDate
         self._predictedSemesterEndValue = predictedSemesterEndValue
         self._axisLabelsYX = axisLabelsYX
-        self._predictedZeroPoint = predictedZeroPoint
+        self._slope = slope
 
         balanceType = type.contains("swipes") ? .swipes : .dollars
 
@@ -70,7 +70,7 @@ struct PredictionsGraphView: View {
             }
             Divider()
                 .padding([.top, .bottom])
-            VariableStepLineGraphView(data: $data, lastPointPosition: $data.wrappedValue.last?.x ?? 0, xAxisLabels: $axisLabelsYX.1, yAxisLabels: $axisLabelsYX.0, lineColor: balanceType == .swipes ? .blue : .green, predictedZeroPoint: $predictedZeroPoint)
+            VariableStepLineGraphView(data: $data, lastPointPosition: $data.wrappedValue.last?.x ?? 0, xAxisLabels: $axisLabelsYX.1, yAxisLabels: $axisLabelsYX.0, lineColor: balanceType == .swipes ? .blue : .green, slope: $slope)
             Divider()
             .padding([.top, .bottom])
 
@@ -79,7 +79,7 @@ struct PredictionsGraphView: View {
                     // "Leftover" Dollars, wasted dollars
                     Text(displayZeroDate ? ("Out of \(balanceType == .swipes ? "Swipes" : "Dollars")") : "Extra Balance")
                         .font(.caption)
-                    Text(displayZeroDate ? "\(self.formattedZeroDate)" : "\(formattedBalance)\(balanceType == .swipes ? " Swipes" : " Dollars")")
+                    Text(displayZeroDate ? "\(self.formattedZeroDate)" : (balanceType == .swipes ? "\(formattedBalance) Swipes" : "$\(formattedBalance)"))
                         .font(Font.system(size: 21, weight: .bold, design: .rounded))
                     Spacer()
                 }

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView+PredictionSlopePath.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView+PredictionSlopePath.swift
@@ -17,8 +17,8 @@ extension VariableStepLineGraphView {
         // This should be the last data point before prediction line begins
         @State var lastDataPoint: PredictionsGraphView.YXDataPoint
 
-        // Calculated day balance will reach 0, computed by the server. X may exceed 1.0 if the zero date is past the end of the semester
-        @State var predictionZeroPoint: PredictionsGraphView.YXDataPoint
+        // Slope of line to be drawn from lastDataPoint
+        @State var slope: Double = 0.0
 
         var animatableData: PredictionsGraphView.YXDataPoint {
             get { return lastDataPoint }
@@ -27,16 +27,26 @@ extension VariableStepLineGraphView {
 
         func path(in rect: CGRect) -> Path {
             var path = Path()
-
             path.move(to: CGPoint(
                 x: lastDataPoint.x * rect.maxX,
                 y: rect.maxY - (rect.maxY * lastDataPoint.y)
             ))
-
-            path.addLine(to: CGPoint(
-                x: predictionZeroPoint.x * rect.maxX,
-                y: rect.maxY - (rect.maxY * predictionZeroPoint.y)
-            ))
+            if slope == 0 {
+                path.addLine(to: CGPoint(
+                    x: rect.maxX,
+                    y: rect.maxY - (rect.maxY * lastDataPoint.y)
+                ))
+            } else if slope.isInfinite {
+                path.addLine(to: CGPoint(
+                    x: rect.maxX,
+                    y: rect.maxY - (rect.maxY * lastDataPoint.y)
+                ))
+            } else {
+                path.addLine(to: CGPoint(
+                    x: rect.maxX,
+                    y: rect.maxY * (1 - lastDataPoint.y - slope * (1 - lastDataPoint.x))
+                ))
+            }
 
             return path
         }

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView+PredictionSlopePath.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView+PredictionSlopePath.swift
@@ -32,6 +32,7 @@ extension VariableStepLineGraphView {
                 y: rect.maxY - (rect.maxY * lastDataPoint.y)
             ))
             if slope.isInfinite {
+                // This case should never actually execute, but it's caught just in case to prevent undefined behavior
                 path.addLine(to: CGPoint(
                     x: rect.maxX,
                     y: rect.maxY - (rect.maxY * lastDataPoint.y)

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView+PredictionSlopePath.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView+PredictionSlopePath.swift
@@ -31,12 +31,7 @@ extension VariableStepLineGraphView {
                 x: lastDataPoint.x * rect.maxX,
                 y: rect.maxY - (rect.maxY * lastDataPoint.y)
             ))
-            if slope == 0 {
-                path.addLine(to: CGPoint(
-                    x: rect.maxX,
-                    y: rect.maxY - (rect.maxY * lastDataPoint.y)
-                ))
-            } else if slope.isInfinite {
+            if slope.isInfinite {
                 path.addLine(to: CGPoint(
                     x: rect.maxX,
                     y: rect.maxY - (rect.maxY * lastDataPoint.y)

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView.swift
@@ -21,7 +21,7 @@ struct VariableStepLineGraphView: View {
     @Binding var xAxisLabels: [String]
     @Binding var yAxisLabels: [String]
     var lineColor: Color
-    @Binding var predictedZeroPoint: PredictionsGraphView.YXDataPoint
+    @Binding var slope: Double
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -54,7 +54,7 @@ struct VariableStepLineGraphView: View {
                                 self.trimEnd = 1.0
                         }
 
-                        PredictionSlopePath(lastDataPoint: self.data.last ?? PredictionsGraphView.YXDataPoint.init(y: 20, x: 20), predictionZeroPoint: self.predictedZeroPoint).stroke(
+                        PredictionSlopePath(lastDataPoint: self.data.last ?? PredictionsGraphView.YXDataPoint.init(y: 20, x: 20), slope: self.slope).stroke(
                             style: StrokeStyle(lineWidth: 2.0, lineCap: .round, lineJoin: .round, dash: [5], dashPhase: 5)
                         )
                             .foregroundColor(.gray)

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/VariableStepLineGraphView.swift
@@ -76,7 +76,7 @@ struct VariableStepLineGraphView: View {
                                 .font(.caption)
                             }
                             .frame(width: 140)
-                            .offset(x: -70 + 5.5 + ((1.0 - 0.5) * geometry.size.width), y: -6 - geometry.size.height/2)
+                            .offset(x: -70 + 5.5 + 1.65 + ((1.0 - 0.5) * geometry.size.width), y: -6 - geometry.size.height/2)
 
                             GraphEndpointPath(x: 1.0).stroke(
                                 style: StrokeStyle(lineWidth: 2.0, lineCap: .round, lineJoin: .round)
@@ -99,6 +99,7 @@ struct VariableStepLineGraphView: View {
                     if label != xAxisLabels.first { Spacer() }
                     Text(label)
                         .font(.subheadline)
+                        .fixedSize()
                         .opacity(0.5)
                 }
             }

--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
@@ -20,13 +20,29 @@ struct DiningVenueDetailMenuView: View {
         }.onChange(of: menuDate) { newMenuDate in
             diningVM.refreshMenu(for: id, at: newMenuDate)
         }
-
-        Text("Penn has recently changed the process in which Penn Labs can access menu data. We are working as fast as possible to fix this. We apologize for the inconvenience.")
-
-//        ForEach(menus, id: \.self) { menu in
-//            DiningMenuRow(for: menu)
-//                .transition(.opacity)
-//        }
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Penn has recently changed the process in which Penn Labs can access menu data. We are working as fast as possible to fix this. We apologize for the inconvenience.")
+            Text("In the meantime, we have directly linked the menu below.")
+        }
+        //        ForEach(menus, id: \.self) { menu in
+        //            DiningMenuRow(for: menu)
+        //                .transition(.opacity)
+        //        }
+        Link(destination: URL(string: DiningVenue.menuUrlDict[id] ?? "https://university-of-pennsylvania.cafebonappetit.com/")!) {
+            CardView {
+                HStack {
+                    Text("Menu")
+                        .font(.system(size: 20, design: .rounded))
+                        .bold()
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                }
+                .padding()
+                .foregroundColor(.blue).font(Font.system(size: 24).weight(.bold))
+            }
+        }
+        .frame(height: 24)
+        .padding([.top])
     }
 }
 


### PR DESCRIPTION
Summary of changes:
- The red dot is centered
- The dates in the graph’s text is not cut off
- Dollar predictions now says “$xxx.00” instead of “xxx.00 Dollars” (so text isn’t cut off)
- The graph uses the (first) maximum value as the start point for predictions
- Rewrote some of the graph stuff (specifically PredictionSlopePath and everything that made a call to it) to take in a slope instead of predictionZeroPoint so we can make the slope as close to 0 as we want.
- In DiningAnalyticsViewModel, condensed the prediction functions into one function that returns the slope of the line, the predicted zero date, and the predicted end balance.
- Slope of infinity (just got dining plan and have/haven’t spent stuff) and slope of 0 (haven’t spent anything on new dining plan) are handled. Both draw a horizontal prediction line.