### PR TITLE
Update mobile backend notifications endpoints

### DIFF
--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -359,16 +359,16 @@ extension UserDBManager {
         }
     }
 
-    func updateNotificationSetting(service: String, enabled: Bool, _ callback: ((_ success: Bool) -> Void)?) {
+    func updateNotificationSetting(id: Int, service: String, enabled: Bool, _ callback: ((_ success: Bool) -> Void)?) {
         OAuth2NetworkManager.instance.getAccessToken { (token) in
             guard let token = token, let payload = try? JSONSerialization.data(withJSONObject: ["service": service, "enabled": enabled]) else {
                 callback?(false)
                 return
             }
 
-            let url = URL(string: "https://pennmobile.org/api/user/notifications/settings/")!
+            let url = URL(string: "https://pennmobile.org/api/user/notifications/settings/\(id)/")!
             var request = URLRequest(url: url, accessToken: token)
-            request.httpMethod = "POST"
+            request.httpMethod = "PATCH"
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = payload
 

--- a/PennMobile/Notifications/Model/NotificationsSetting.swift
+++ b/PennMobile/Notifications/Model/NotificationsSetting.swift
@@ -9,13 +9,9 @@
 import Foundation
 
 struct NotificationSetting: Codable, Identifiable {
-    let id: NotificationPreference
+    let id: Int
+    let service: NotificationPreference
     var enabled: Bool
-
-    enum CodingKeys: String, CodingKey {
-        case enabled
-        case id = "service"
-    }
 }
 
 enum NotificationPreference: String, Codable {

--- a/PennMobile/Notifications/SwiftUI/NotificationViewModel.swift
+++ b/PennMobile/Notifications/SwiftUI/NotificationViewModel.swift
@@ -23,7 +23,7 @@ class NotificationViewModel: ObservableObject {
     }
 
     func requestChange(service: NotificationSetting, toValue: Bool) async {
-        UserDBManager.shared.updateNotificationSetting(service: service.id.rawValue, enabled: toValue) { result in
+        UserDBManager.shared.updateNotificationSetting(id: service.id, service: service.service.rawValue, enabled: toValue) { result in
             if !result {
                 self.shouldShowError = true
             }

--- a/PennMobile/Notifications/SwiftUI/NotificationsView.swift
+++ b/PennMobile/Notifications/SwiftUI/NotificationsView.swift
@@ -20,9 +20,9 @@ struct NotificationsView: View, NotificationRequestable {
     var body: some View {
         Form {
             ForEach($notificationViewModel.notificationSettings) { $setting in
-                if NotificationPreference.visibleOptions.contains($setting.id) {
-                    Section(footer: Text($setting.id.description)) {
-                        Toggle($setting.id.title, isOn: $setting.enabled)
+                if NotificationPreference.visibleOptions.contains(setting.service) {
+                    Section(footer: Text(setting.service.description)) {
+                        Toggle(setting.service.title, isOn: $setting.enabled)
                             .onChange(of: $setting.enabled.wrappedValue) { value in
                                 Task.init(operation: { await notificationViewModel.requestChange(service: setting, toValue: value) })
                             }


### PR DESCRIPTION
Use `PATCH` request with service `id` instead of `POST` request with service name / title to update user notification preferences.