### PR TITLE
Course Schedule: Show login controller on authentication failure

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		89459B9928E7999A00CE1638 /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89459B9828E7999A00CE1638 /* Course.swift */; };
 		89459B9B28E799AA00CE1638 /* CoursesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89459B9A28E799AA00CE1638 /* CoursesViewModel.swift */; };
 		89459B9D28E7E8A600CE1638 /* CoursesDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89459B9C28E7E8A600CE1638 /* CoursesDayView.swift */; };
+		895C75E628FA165100A329A0 /* LabsLoginSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895C75E528FA165100A329A0 /* LabsLoginSwiftUI.swift */; };
 		89B454DF28E1161B00BC918B /* PathAtPennNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B454DE28E1161B00BC918B /* PathAtPennNetworkManager.swift */; };
 		89DCBEC628E791B70029F784 /* CoursesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DCBEC528E791B70029F784 /* CoursesViewController.swift */; };
 		97AA806C23D26BC700C23488 /* DiningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AA806723D26BC700C23488 /* DiningCell.swift */; };
@@ -513,6 +514,7 @@
 		89459B9828E7999A00CE1638 /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		89459B9A28E799AA00CE1638 /* CoursesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesViewModel.swift; sourceTree = "<group>"; };
 		89459B9C28E7E8A600CE1638 /* CoursesDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesDayView.swift; sourceTree = "<group>"; };
+		895C75E528FA165100A329A0 /* LabsLoginSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabsLoginSwiftUI.swift; sourceTree = "<group>"; };
 		89B454DE28E1161B00BC918B /* PathAtPennNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathAtPennNetworkManager.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		89DCBEC528E791B70029F784 /* CoursesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesViewController.swift; sourceTree = "<group>"; };
 		97AA806723D26BC700C23488 /* DiningCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningCell.swift; sourceTree = "<group>"; };
@@ -1090,6 +1092,7 @@
 			isa = PBXGroup;
 			children = (
 				21737FD623A1DEE7002DCD07 /* LabsLoginController.swift */,
+				895C75E528FA165100A329A0 /* LabsLoginSwiftUI.swift */,
 				21F70D242346AB3400CEB203 /* CampusExpressLoginController.swift */,
 				21B8BBB522231F9F00EBC1D0 /* Account.swift */,
 				21B8BBB72223963C00EBC1D0 /* Degree.swift */,
@@ -2172,6 +2175,7 @@
 				C11DFA31219F90E5000FC573 /* CalendarEvent.swift in Sources */,
 				6CC88D6B27B1BF51006896F6 /* DiningVenueView.swift in Sources */,
 				6C11C08026F842CF00407C04 /* HomeUpdateCellItem.swift in Sources */,
+				895C75E628FA165100A329A0 /* LabsLoginSwiftUI.swift in Sources */,
 				97E79E072100DA1200D3D606 /* BuildingImageCell.swift in Sources */,
 				217A783F204D97F8004F1227 /* ModularTableViewItem.swift in Sources */,
 				212209A71EC7CD2F0038FB7F /* MoveableTableViewController.swift in Sources */,

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
@@ -29,7 +29,7 @@ class DiningAnalyticsViewModel: ObservableObject {
     @Published var dollarAxisLabel: ([String], [String]) = ([], [])
     @Published var dollarSlope: Double = 0.0
     @Published var swipeSlope: Double = 0.0
-    
+
     var yIntercept = 0.0
     var slope = 0.0
     let formatter = DateFormatter()

--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -470,7 +470,7 @@ extension UserDBManager {
             "token": deviceToken,
             "dev": false
         ]
-        
+
         #if DEBUG
             params["dev"] = true
         #endif

--- a/PennMobile/Login/LabsLoginSwiftUI.swift
+++ b/PennMobile/Login/LabsLoginSwiftUI.swift
@@ -1,0 +1,43 @@
+//
+//  PennLoginSwiftUI.swift
+//  PennMobile
+//
+//  Created by Anthony Li on 10/14/22.
+//  Copyright © 2022 PennLabs. All rights reserved.
+//
+
+import SwiftUI
+
+/// View that presents the Penn Mobile login flow, typically used in a modal context.
+struct LabsLoginView: UIViewControllerRepresentable {
+    /// Callback on success or cancellation.
+    ///
+    /// Passed `true` if the login succeeds, or `false` if the login was cancelled.
+    var onCompletion: (Bool) -> Void
+
+    func makeUIViewController(context: Context) -> LabsLoginController {
+        return LabsLoginController { success in
+            context.coordinator.dispatchCompletion(success: success)
+        }
+    }
+
+    func updateUIViewController(_ uiViewController: LabsLoginController, context: Context) {
+        context.coordinator.parent = self
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator {
+        var parent: LabsLoginView
+
+        init(_ parent: LabsLoginView) {
+            self.parent = parent
+        }
+
+        func dispatchCompletion(success: Bool) {
+            parent.onCompletion(success)
+        }
+    }
+}


### PR DESCRIPTION
Sometimes Path@Penn doesn't give us a token if we attempt a login, likely due to some sort of expired cookie. This PR implements a quick and dirty SwiftUI `LabsLoginView` and presents it if it detects an authentication failure.
