### PR TITLE
Course Schedule: Show loading indicator after successful login

### DIFF
--- a/PennMobile/Courses/Views/CoursesView.swift
+++ b/PennMobile/Courses/Views/CoursesView.swift
@@ -84,6 +84,7 @@ struct CoursesView: View {
         }.sheet(isPresented: $isPresentingLoginSheet) {
             LabsLoginView { success in
                 if success {
+                    coursesViewModel.coursesResult = nil
                     Task {
                         try? await coursesViewModel.fetchCourses(forceNetwork: true)
                     }


### PR DESCRIPTION
Fixes a quick UI issue where the error page would still be visible for a few seconds after the user logs in while the app fetches the courses.