### PR TITLE
Made dining analytics graph use dining plan start date for prediction

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		21F70D252346AB3800CEB203 /* CampusExpressLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F70D242346AB3400CEB203 /* CampusExpressLoginController.swift */; };
 		21FBC240228514ED00B432D8 /* FeedAnalyticsEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FBC23F228514ED00B432D8 /* FeedAnalyticsEngine.swift */; };
 		21FBC242228B774E00B432D8 /* PennCashNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FBC241228B774E00B432D8 /* PennCashNetworkManager.swift */; };
+		425E281B28FF5EE200218F50 /* DiningPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425E281A28FF5EE200218F50 /* DiningPlan.swift */; };
 		56D74230B1B43DAF260BCCBE /* Pods_PennMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BED8AA4945D67F0ED89FA9B0 /* Pods_PennMobile.framework */; };
 		6C11C08026F842CF00407C04 /* HomeUpdateCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C11C07F26F842CF00407C04 /* HomeUpdateCellItem.swift */; };
 		6C1991BB27B5C73800BBB402 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1991BA27B5C73800BBB402 /* Environment.swift */; };
@@ -435,6 +436,7 @@
 		22D5D1D7F760F28A27C06241 /* libPods-AutomatedScreenshotUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutomatedScreenshotUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F8A024230F1E8D7BA9410B4 /* Pods-AutomatedScreenshotUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedScreenshotUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedScreenshotUITests/Pods-AutomatedScreenshotUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		407FC3CFC29C6496A17C99C2 /* Pods-AutomatedScreenshotUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedScreenshotUITests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedScreenshotUITests/Pods-AutomatedScreenshotUITests.release.xcconfig"; sourceTree = "<group>"; };
+		425E281A28FF5EE200218F50 /* DiningPlan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningPlan.swift; sourceTree = "<group>"; };
 		6C11C07F26F842CF00407C04 /* HomeUpdateCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUpdateCellItem.swift; sourceTree = "<group>"; };
 		6C1991BA27B5C73800BBB402 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		6C1991BC27B5CA4D00BBB402 /* NotificationDevelopment.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NotificationDevelopment.xcconfig; sourceTree = "<group>"; };
@@ -856,6 +858,7 @@
 		2166408D1EBADC0100746B8E /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				425E281A28FF5EE200218F50 /* DiningPlan.swift */,
 				6CC88D7A27B1BFB0006896F6 /* DiningToken.swift */,
 				E515B36227C2B97500AAE0D8 /* DiningBalance.swift */,
 				E50676E927EE1C73009A776E /* PastDiningBalances.swift */,
@@ -2093,6 +2096,7 @@
 				F212BE8823B71C7100ED46A1 /* NotificationsTableViewController.swift in Sources */,
 				6CC88D6527B1BF51006896F6 /* PredictionsGraphView+AxisLabels.swift in Sources */,
 				21F5F8F320538A90005B143F /* HomeFlingCell.swift in Sources */,
+				425E281B28FF5EE200218F50 /* DiningPlan.swift in Sources */,
 				212B8355222A31B500F835D6 /* HomePostCellItem.swift in Sources */,
 				97E79E062100DA1200D3D606 /* BuildingMapCell.swift in Sources */,
 				6CC88D7727B1BF51006896F6 /* DiningAnalyticsView.swift in Sources */,

--- a/PennMobile/Dining/Model/DiningPlan.swift
+++ b/PennMobile/Dining/Model/DiningPlan.swift
@@ -1,0 +1,20 @@
+//
+//  DiningPlan.swift
+//  PennMobile
+//
+//  Created by Jordan H on 10/18/22.
+//  Copyright © 2022 PennLabs. All rights reserved.
+//
+
+import Foundation
+
+struct DiningPlan: Codable {
+    let name: String
+    let description: String
+    let start_date: Date
+    let end_date: Date
+    let signup_date: Date
+    let cost: String
+    let dining_dollars: String
+    let total_visits: Int
+}

--- a/PennMobile/Dining/Networking + Cache/DiningAPI.swift
+++ b/PennMobile/Dining/Networking + Cache/DiningAPI.swift
@@ -140,23 +140,22 @@ extension DiningAPI {
 
 // MARK: Current Dining Plan Start Date
 extension DiningAPI {
-    func getDiningPlanStartDate(diningToken: String, _ callback: @escaping (_ startDate: Date?) -> Void) {
+    func getDiningPlanStartDate(diningToken: String) async -> Result<Date, NetworkingError> {
         let url = URL(string: "https://prod.campusexpress.upenn.edu/api/v1/dining/currentPlan")!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue(diningToken, forHTTPHeaderField: "x-authorization")
-        let task = URLSession.shared.dataTask(with: request) { (data, response, _ ) in
-            if let httpResponse = response as? HTTPURLResponse, let data = data, httpResponse.statusCode == 200 {
-                let decoder = JSONDecoder()
-                let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "yyyy-MM-dd"
-                decoder.dateDecodingStrategy = .formatted(dateFormatter)
-                let plan = try? decoder.decode(DiningPlan.self, from: data)
-                callback(plan?.start_date)
-                return
-            }
-            callback(nil)
+        guard let (data, response) = try? await URLSession.shared.data(for: request), let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            return .failure(.serverError)
         }
-        task.resume()
+        let decoder = JSONDecoder()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        if let plan = try? decoder.decode(DiningPlan.self, from: data) {
+            return .success(plan.start_date)
+        } else {
+            return .failure(.parsingError)
+        }
     }
 }

--- a/PennMobile/Dining/Networking + Cache/DiningAPI.swift
+++ b/PennMobile/Dining/Networking + Cache/DiningAPI.swift
@@ -137,3 +137,26 @@ extension DiningAPI {
         task.resume()
     }
 }
+
+// MARK: Current Dining Plan Start Date
+extension DiningAPI {
+    func getDiningPlanStartDate(diningToken: String, _ callback: @escaping (_ startDate: Date?) -> Void) {
+        let url = URL(string: "https://prod.campusexpress.upenn.edu/api/v1/dining/currentPlan")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(diningToken, forHTTPHeaderField: "x-authorization")
+        let task = URLSession.shared.dataTask(with: request) { (data, response, _ ) in
+            if let httpResponse = response as? HTTPURLResponse, let data = data, httpResponse.statusCode == 200 {
+                let decoder = JSONDecoder()
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd"
+                decoder.dateDecodingStrategy = .formatted(dateFormatter)
+                let plan = try? decoder.decode(DiningPlan.self, from: data)
+                callback(plan?.start_date)
+                return
+            }
+            callback(nil)
+        }
+        task.resume()
+    }
+}

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
@@ -57,12 +57,12 @@ struct DiningAnalyticsView: View {
             }
             .padding()
         }
-        .onAppear {
+        .task {
             guard Account.isLoggedIn, KeychainAccessible.instance.getDiningToken() != nil, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration else {
                 showMissingDiningTokenAlert = true
                 return
             }
-            diningAnalyticsViewModel.refresh()
+            await diningAnalyticsViewModel.refresh()
         }
         .alert(isPresented: $showMissingDiningTokenAlert) {
             showCorrectAlert()

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
@@ -56,7 +56,7 @@ class DiningAnalyticsViewModel: ObservableObject {
             startDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
         }
         let startDateStr = formatter.string(from: startDate)
-        let planStartDate = await DiningAPI.instance.getDiningPlanStartDate(diningToken: diningToken)
+        let planStartDateResult = await DiningAPI.instance.getDiningPlanStartDate(diningToken: diningToken)
         DiningAPI.instance.getPastDiningBalances(diningToken: diningToken, startDate: startDateStr) { (balances) in
             guard let balances = balances else {
                 return
@@ -80,23 +80,21 @@ class DiningAnalyticsViewModel: ObservableObject {
             // If no dining plan found, refresh will return, these are just placeholders
             var startDollarBalance = maxDollarBalance
             var startSwipeBalance = maxSwipeBalance
-            switch planStartDate {
-            case .failure(_):
+            switch planStartDateResult {
+            case .failure:
                 return
-            case .success(let date):
+            case .success(let planStartDate):
                 // If dining plan found, start prediction from the date dining plan started
-                startDollarBalance = (self.dollarHistory.first { $0.date == date }) ?? startDollarBalance
-                startSwipeBalance = (self.swipeHistory.first { $0.date == date }) ?? startSwipeBalance
+                startDollarBalance = (self.dollarHistory.first { $0.date == planStartDate }) ?? startDollarBalance
+                startSwipeBalance = (self.swipeHistory.first { $0.date == planStartDate }) ?? startSwipeBalance
                 // However, it's possible that people recharged dining dollars (swipes maybe?), and if so, predict from this date (most recent increase)
                 for (i, day) in self.dollarHistory.enumerated() {
-                    if i > 0 && Calendar.current.compare(day.date, to: date, toGranularity: .day) == ComparisonResult.orderedDescending
-                        && day.balance > self.dollarHistory[i - 1].balance {
+                    if i != 0 && day.date > planStartDate && day.balance > self.dollarHistory[i - 1].balance {
                         startDollarBalance = day
                     }
                 }
                 for (i, day) in self.swipeHistory.enumerated() {
-                    if i > 0 && Calendar.current.compare(day.date, to: date, toGranularity: .day) == ComparisonResult.orderedDescending
-                        && day.balance > self.swipeHistory[i - 1].balance {
+                    if i != 0 && day.date > planStartDate && day.balance > self.swipeHistory[i - 1].balance {
                         startSwipeBalance = day
                     }
                 }

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
@@ -56,6 +56,7 @@ class DiningAnalyticsViewModel: ObservableObject {
             startDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
         }
         let startDateStr = formatter.string(from: startDate)
+        let planStartDate = await DiningAPI.instance.getDiningPlanStartDate(diningToken: diningToken)
         DiningAPI.instance.getPastDiningBalances(diningToken: diningToken, startDate: startDateStr) { (balances) in
             guard let balances = balances else {
                 return
@@ -78,7 +79,6 @@ class DiningAnalyticsViewModel: ObservableObject {
             }
             let maxDollarBalance = startDollarBalance
             let maxSwipeBalance = startSwipeBalance
-            let planStartDate = await DiningAPI.instance.getDiningPlanStartDate(diningToken: diningToken)
             switch planStartDate {
             case .success(let date):
                 startDollarBalance = (self.dollarHistory.first { $0.date == date }) ?? startDollarBalance

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsViewModel.swift
@@ -80,7 +80,6 @@ class DiningAnalyticsViewModel: ObservableObject {
             // If no dining plan found, refresh will return, these are just placeholders
             var startDollarBalance = maxDollarBalance
             var startSwipeBalance = maxSwipeBalance
-            let planStartDate = await DiningAPI.instance.getDiningPlanStartDate(diningToken: diningToken)
             switch planStartDate {
             case .failure(_):
                 return

--- a/PennMobile/Dining/SwiftUI/DiningLoginViewSwiftUI.swift
+++ b/PennMobile/Dining/SwiftUI/DiningLoginViewSwiftUI.swift
@@ -33,7 +33,9 @@ struct DiningLoginViewSwiftUI: UIViewControllerRepresentable {
         func dismissDiningLoginController() {
             parent.presentationMode.wrappedValue.dismiss()
             DiningViewModelSwiftUI.instance.refreshBalance()
-            parent.diningAnalyticsViewModel.refresh()
+            Task.init() {
+                await parent.diningAnalyticsViewModel.refresh()
+            }
         }
     }
 


### PR DESCRIPTION
Before, we updated dining analytics graph to use the maximum values, but I realized this doesn't always work. It's possible for a change in dining plan to reduce swipes or dollars, so this change is necessary.

Note, since I added a file, I wasn't sure if I should commit PennMobile.xcodeproj/project.pbxproj. Please let me know if I should do this.