### PR TITLE
Improve refreshing on the dining screen

### DIFF
--- a/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
@@ -25,13 +25,30 @@ struct DiningVenueView: View {
         }
 
         refreshState = .refreshing(Task {
-            await diningVM.refreshVenues()
-            await diningVM.refreshBalance()
-            await diningVM.refreshMenus(cache: true)
-
-            // Only refresh widgets once
-            await diningAnalyticsViewModel.refresh(refreshWidgets: widgetsNeedRefresh)
-            widgetsNeedRefresh = false
+            let venueTask = Task {
+                await diningVM.refreshVenues()
+            }
+            
+            let balanceTask = Task {
+                await diningVM.refreshBalance()
+            }
+            
+            let menuTask = Task {
+                await diningVM.refreshMenus(cache: true)
+            }
+            
+            let analyticsTask = Task {
+                // Only refresh widgets once
+                await diningAnalyticsViewModel.refresh(refreshWidgets: widgetsNeedRefresh)
+                if !Task.isCancelled {
+                    widgetsNeedRefresh = false
+                }
+            }
+            
+            await venueTask.value
+            await balanceTask.value
+            await menuTask.value
+            await analyticsTask.value
 
             refreshState = .refreshed
         })

--- a/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
@@ -98,8 +98,8 @@ struct CustomHeader: View {
 
     func animateButton(refreshing brrrr: Bool) {
         if brrrr {
-            withAnimation(.linear(duration: 1).repeatForever(autoreverses: true)) {
-                buttonAngle = .degrees(360)
+            withAnimation(.linear(duration: 1).repeatForever(autoreverses: Int.random(in: 0..<50) == 0)) {
+                buttonAngle = .degrees(-360)
             }
         } else {
             withAnimation {
@@ -136,8 +136,8 @@ struct CustomHeader: View {
 
                     refresh()
                 }, label: {
-                    Image(systemName: "arrow.counterclockwise")
-                }).rotationEffect(buttonAngle)
+                    Image(systemName: "arrow.counterclockwise.circle.fill").imageScale(.large).rotationEffect(buttonAngle)
+                })
             default:
                 Group {}
             }

--- a/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
@@ -84,6 +84,7 @@ struct CustomHeader: View {
     @State var showDiningLoginView = false
     @State var buttonAngle: Angle = .zero
     @Environment(\.presentationMode) var presentationMode
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
     @EnvironmentObject var diningAnalyticsViewModel: DiningAnalyticsViewModel
     func showCorrectAlert () -> Alert {
         if !Account.isLoggedIn {
@@ -98,7 +99,7 @@ struct CustomHeader: View {
 
     func animateButton(refreshing brrrr: Bool) {
         if brrrr {
-            withAnimation(.linear(duration: 1).repeatForever(autoreverses: Int.random(in: 0..<50) == 0)) {
+            withAnimation(.linear(duration: 1).repeatForever(autoreverses: reduceMotion || Int.random(in: 0..<50) == 0)) {
                 buttonAngle = .degrees(-360)
             }
         } else {
@@ -136,7 +137,10 @@ struct CustomHeader: View {
 
                     refresh()
                 }, label: {
-                    Image(systemName: "arrow.counterclockwise.circle.fill").imageScale(.large).rotationEffect(buttonAngle)
+                    Image(systemName: "arrow.counterclockwise.circle.fill")
+                        .imageScale(.large)
+                        .rotationEffect(reduceMotion ? .zero : buttonAngle)
+                        .opacity(reduceMotion ? 1 + (buttonAngle.degrees / 360) : (isRefreshing ? 0.5 : 1))
                 })
             default:
                 Group {}

--- a/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
@@ -141,6 +141,7 @@ struct CustomHeader: View {
                         .imageScale(.large)
                         .rotationEffect(reduceMotion ? .zero : buttonAngle)
                         .opacity(reduceMotion ? 1 + (buttonAngle.degrees / 360) : (isRefreshing ? 0.5 : 1))
+                        .accessibilityLabel(Text(isRefreshing ? "Refreshing" : "Refresh"))
                 })
             default:
                 Group {}

--- a/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
@@ -97,8 +97,8 @@ struct CustomHeader: View {
         }
     }
 
-    func animateButton(refreshing brrrr: Bool) {
-        if brrrr {
+    func animateButton(refreshing: Bool) {
+        if refreshing {
             withAnimation(.linear(duration: 1).repeatForever(autoreverses: reduceMotion || Int.random(in: 0..<50) == 0)) {
                 buttonAngle = .degrees(-360)
             }
@@ -159,8 +159,8 @@ struct CustomHeader: View {
         .onAppear {
             animateButton(refreshing: isRefreshing)
         }
-        .onChange(of: isRefreshing) { brrrr in
-            animateButton(refreshing: brrrr)
+        .onChange(of: isRefreshing) { refreshing in
+            animateButton(refreshing: refreshing)
         }
 
         // Note: The Alert view is soon to be deprecated, but .alert(_:isPresented:presenting:actions:message:) is available in iOS15+

--- a/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/DiningVenueView.swift
@@ -9,12 +9,45 @@
 import SwiftUI
 
 struct DiningVenueView: View {
+    enum RefreshState {
+        case refreshing(Task<Void, Never>?)
+        case refreshed
+    }
+
     @EnvironmentObject var diningVM: DiningViewModelSwiftUI
     @StateObject var diningAnalyticsViewModel = DiningAnalyticsViewModel()
+    @State var refreshState = RefreshState.refreshing(nil)
+    @State var widgetsNeedRefresh = true
+
+    func triggerRefresh() {
+        if case .refreshing(let task) = refreshState {
+            task?.cancel()
+        }
+
+        refreshState = .refreshing(Task {
+            await diningVM.refreshVenues()
+            await diningVM.refreshBalance()
+            await diningVM.refreshMenus(cache: true)
+
+            // Only refresh widgets once
+            await diningAnalyticsViewModel.refresh(refreshWidgets: widgetsNeedRefresh)
+            widgetsNeedRefresh = false
+
+            refreshState = .refreshed
+        })
+    }
 
     var body: some View {
-        List {
-            Section(header: CustomHeader(name: "Dining Balance", refreshButton: true).environmentObject(diningAnalyticsViewModel), content: {
+        let refreshConfiguration: CustomHeader.RefreshConfiguration
+        switch refreshState {
+        case .refreshed:
+            refreshConfiguration = .refreshed(triggerRefresh)
+        default:
+            refreshConfiguration = .refreshing
+        }
+
+        return List {
+            Section(header: CustomHeader(name: "Dining Balance", refreshConfiguration: refreshConfiguration).environmentObject(diningAnalyticsViewModel), content: {
                 Section(header: DiningViewHeader().environmentObject(diningAnalyticsViewModel), content: {})
             })
 
@@ -29,11 +62,8 @@ struct DiningVenueView: View {
                 }
             }
         }
-        .task {
-            await diningVM.refreshVenues()
-            await diningVM.refreshBalance()
-            await diningVM.refreshMenus(cache: true)
-            await diningAnalyticsViewModel.refresh(refreshWidgets: true)
+        .onAppear {
+            triggerRefresh()
         }
         .navigationBarHidden(false)
         .listStyle(.plain)
@@ -41,12 +71,18 @@ struct DiningVenueView: View {
 }
 
 struct CustomHeader: View {
+    enum RefreshConfiguration {
+        case noRefresh
+        case refreshing
+        case refreshed(() -> Void)
+    }
 
     let name: String
-    var refreshButton = false
+    var refreshConfiguration = RefreshConfiguration.noRefresh
     @State var didError = false
     @State var showMissingDiningTokenAlert = false
     @State var showDiningLoginView = false
+    @State var buttonAngle: Angle = .zero
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var diningAnalyticsViewModel: DiningAnalyticsViewModel
     func showCorrectAlert () -> Alert {
@@ -60,25 +96,50 @@ struct CustomHeader: View {
         }
     }
 
+    func animateButton(refreshing brrrr: Bool) {
+        if brrrr {
+            withAnimation(.linear(duration: 1).repeatForever(autoreverses: true)) {
+                buttonAngle = .degrees(360)
+            }
+        } else {
+            withAnimation {
+                buttonAngle = .zero
+            }
+        }
+    }
+
     var body: some View {
-        HStack {
+        let isRefreshing: Bool
+        if case .refreshing = refreshConfiguration {
+            isRefreshing = true
+        } else {
+            isRefreshing = false
+        }
+
+        return HStack {
             Text(name)
                 .font(.system(size: 21, weight: .semibold))
                 .foregroundColor(.primary)
             Spacer()
-            if refreshButton {
+            switch refreshConfiguration {
+            case .refreshed, .refreshing:
                 Button(action: {
+                    guard case .refreshed(let refresh) = refreshConfiguration else {
+                        return
+                    }
+
                     guard Account.isLoggedIn, KeychainAccessible.instance.getDiningToken() != nil, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration else {
                         print("Should show alert")
                         showMissingDiningTokenAlert = true
                         return
                     }
-                    Task.init {
-                        await DiningViewModelSwiftUI.instance.refreshBalance()
-                    }
+
+                    refresh()
                 }, label: {
                     Image(systemName: "arrow.counterclockwise")
-                })
+                }).rotationEffect(buttonAngle)
+            default:
+                Group {}
             }
         }
         .padding()
@@ -89,6 +150,12 @@ struct CustomHeader: View {
         .sheet(isPresented: $showDiningLoginView) {
             DiningLoginNavigationView()
                 .environmentObject(diningAnalyticsViewModel)
+        }
+        .onAppear {
+            animateButton(refreshing: isRefreshing)
+        }
+        .onChange(of: isRefreshing) { brrrr in
+            animateButton(refreshing: brrrr)
         }
 
         // Note: The Alert view is soon to be deprecated, but .alert(_:isPresented:presenting:actions:message:) is available in iOS15+


### PR DESCRIPTION
This PR:

1. Stops refreshes from being cancelled when the dining analytics screen is entered (fixing that weird dining analytics refresh cancellation issue)
2. Adds :sparkles: ***animation*** :sparkles:

https://user-images.githubusercontent.com/7005789/213819740-5efd7731-cf6e-4987-8543-b6c532db4bf6.mov

Blame @JHawk0224 for this. In other news, please send help