### PR TITLE
Made new analytics graph with support for touching the graph

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		21F70D252346AB3800CEB203 /* CampusExpressLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F70D242346AB3400CEB203 /* CampusExpressLoginController.swift */; };
 		21FBC240228514ED00B432D8 /* FeedAnalyticsEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FBC23F228514ED00B432D8 /* FeedAnalyticsEngine.swift */; };
 		21FBC242228B774E00B432D8 /* PennCashNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FBC241228B774E00B432D8 /* PennCashNetworkManager.swift */; };
+		426A0B51299034910066C7B7 /* DiningAnalyticsGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426A0B4F299034910066C7B7 /* DiningAnalyticsGraph.swift */; };
+		426A0B52299034910066C7B7 /* DiningAnalyticsGraphBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426A0B50299034910066C7B7 /* DiningAnalyticsGraphBox.swift */; };
 		56D74230B1B43DAF260BCCBE /* Pods_PennMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BED8AA4945D67F0ED89FA9B0 /* Pods_PennMobile.framework */; };
 		6C11C08026F842CF00407C04 /* HomeUpdateCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C11C07F26F842CF00407C04 /* HomeUpdateCellItem.swift */; };
 		6C1991BB27B5C73800BBB402 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1991BA27B5C73800BBB402 /* Environment.swift */; };
@@ -484,6 +486,8 @@
 		2F8A024230F1E8D7BA9410B4 /* Pods-AutomatedScreenshotUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedScreenshotUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedScreenshotUITests/Pods-AutomatedScreenshotUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		407FC3CFC29C6496A17C99C2 /* Pods-AutomatedScreenshotUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedScreenshotUITests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedScreenshotUITests/Pods-AutomatedScreenshotUITests.release.xcconfig"; sourceTree = "<group>"; };
 		425E281A28FF5EE200218F50 /* DiningPlan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningPlan.swift; sourceTree = "<group>"; };
+		426A0B4F299034910066C7B7 /* DiningAnalyticsGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsGraph.swift; sourceTree = "<group>"; };
+		426A0B50299034910066C7B7 /* DiningAnalyticsGraphBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsGraphBox.swift; sourceTree = "<group>"; };
 		6C11C07F26F842CF00407C04 /* HomeUpdateCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUpdateCellItem.swift; sourceTree = "<group>"; };
 		6C1991BA27B5C73800BBB402 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		6C1991BC27B5CA4D00BBB402 /* NotificationDevelopment.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NotificationDevelopment.xcconfig; sourceTree = "<group>"; };
@@ -1370,6 +1374,8 @@
 		6CC88D3F27B1BF50006896F6 /* PredictionsGraph */ = {
 			isa = PBXGroup;
 			children = (
+				426A0B4F299034910066C7B7 /* DiningAnalyticsGraph.swift */,
+				426A0B50299034910066C7B7 /* DiningAnalyticsGraphBox.swift */,
 				6CC88D4027B1BF50006896F6 /* VariableStepLineGraphView+GraphEndpointPath.swift */,
 				6CC88D4127B1BF50006896F6 /* PredictionsGraphView+SmoothedData.swift */,
 				6CC88D4227B1BF50006896F6 /* PredictionsGraphView.swift */,
@@ -2273,6 +2279,7 @@
 				6C84D9E526293E680039C57F /* UIKit Views.swift in Sources */,
 				21B649242236FFD300AC5B7F /* BuildingMapWebviewController.swift in Sources */,
 				89459B9428E7935E00CE1638 /* CoursesView.swift in Sources */,
+				426A0B52299034910066C7B7 /* DiningAnalyticsGraphBox.swift in Sources */,
 				E50676EC27F0CA39009A776E /* DiningAnalyticsViewModel.swift in Sources */,
 				F212BE7F23B6ACF100ED46A1 /* PrivacyTableViewController.swift in Sources */,
 				217A7830204D2C72004F1227 /* HomeItemTypes.swift in Sources */,
@@ -2409,6 +2416,7 @@
 				C15C4B4E223EB16F00E443FD /* HomeReservationsCell.swift in Sources */,
 				B62875F92118F95300FB2873 /* BuildingProtocol.swift in Sources */,
 				F212BE8623B6DA8D00ED46A1 /* PrivacyTableViewCell.swift in Sources */,
+				426A0B51299034910066C7B7 /* DiningAnalyticsGraph.swift in Sources */,
 				97AA806C23D26BC700C23488 /* DiningCell.swift in Sources */,
 				6C6FE1CC27B9B8CB0093FD13 /* PacCodeNetworkManager.swift in Sources */,
 				6CC88D5927B1BF51006896F6 /* DiningLoginViewSwiftUI.swift in Sources */,

--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
@@ -25,69 +25,124 @@ struct DiningAnalyticsView: View {
         }
     }
     var body: some View {
-        let dollarXYHistory = Binding(
-            get: {
-                getSmoothedData(from: diningAnalyticsViewModel.dollarHistory)
-            },
-            // one directional Binding, setter does not work
-            set: {  _ in }
-        )
-        let swipeXYHistory = Binding(
-            get: { getSmoothedData(from: diningAnalyticsViewModel.swipeHistory) },
-            // one directional Binding, setter does not work
-            set: {  _ in }
-        )
-        HStack {
-            if Account.isLoggedIn, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration {
-                if swipeXYHistory.wrappedValue.isEmpty && dollarXYHistory.wrappedValue.isEmpty {
-                    ZStack {
-                        Image("DiningAnalyticsBackground")
-                            .resizable()
-                            .ignoresSafeArea()
-                        Text("No Dining\nPlan Found\n ")
-                            .multilineTextAlignment(.center)
-                            .font(.system(size: 48, weight: .regular))
-                            .foregroundColor(.black)
-                            .opacity(0.6)
-                    }
-                } else {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 20) {
-                            Text("Dining Analytics")
-                                .font(.system(size: 32))
-                                .bold()
-                            // Only show dollar history view if there is data for the graph
-                            if !dollarXYHistory.wrappedValue.isEmpty {
-                                CardView {
-                                    PredictionsGraphView(type: "dollars", data: dollarXYHistory, predictedZeroDate: $diningAnalyticsViewModel.dollarPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedDollarSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.dollarAxisLabel, slope: $diningAnalyticsViewModel.dollarSlope)
-                                }
-                            }
-                            // Only show swipe history view if there is data for the graph
-                            if !swipeXYHistory.wrappedValue.isEmpty {
-                                CardView {
-                                    PredictionsGraphView(type: "swipes", data:
-                                                            swipeXYHistory, predictedZeroDate: $diningAnalyticsViewModel.swipesPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedSwipesSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.swipeAxisLabel, slope: $diningAnalyticsViewModel.swipeSlope)
-                                }
-                            }
-                            Spacer()
+        if #available(iOS 16.0, *) {
+            let dollarHistory = $diningAnalyticsViewModel.dollarHistory
+            let swipeHistory = $diningAnalyticsViewModel.swipeHistory
+            HStack {
+                if Account.isLoggedIn, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration {
+                    if dollarHistory.wrappedValue.isEmpty && swipeHistory.wrappedValue.isEmpty {
+                        ZStack {
+                            Image("DiningAnalyticsBackground")
+                                .resizable()
+                                .ignoresSafeArea()
+                            Text("No Dining\nPlan Found\n ")
+                                .multilineTextAlignment(.center)
+                                .font(.system(size: 48, weight: .regular))
+                                .foregroundColor(.black)
+                                .opacity(0.6)
                         }
-                        .padding()
+                    } else {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 20) {
+                                Text("Dining Analytics")
+                                    .font(.system(size: 32))
+                                    .bold()
+                                // Only show dollar history view if there is data for the graph
+                                if !dollarHistory.wrappedValue.isEmpty {
+                                    CardView {
+                                        GraphView(type: .dollars, data: dollarHistory, predictedZeroDate: $diningAnalyticsViewModel.dollarPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedDollarSemesterEndBalance)
+                                    }
+                                }
+                                // Only show swipe history view if there is data for the graph
+                                if !swipeHistory.wrappedValue.isEmpty {
+                                    CardView {
+                                        GraphView(type: .swipes, data: swipeHistory, predictedZeroDate: $diningAnalyticsViewModel.swipesPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedSwipesSemesterEndBalance)
+                                    }
+                                }
+                                Spacer()
+                            }
+                            .padding()
+                        }
                     }
                 }
             }
-        }
-        .task {
-            guard Account.isLoggedIn, KeychainAccessible.instance.getDiningToken() != nil, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration else {
-                showMissingDiningTokenAlert = true
-                return
+            .task {
+                guard Account.isLoggedIn, KeychainAccessible.instance.getDiningToken() != nil, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration else {
+                    showMissingDiningTokenAlert = true
+                    return
+                }
             }
-        }
-        .alert(isPresented: $showMissingDiningTokenAlert) {
-            showCorrectAlert()
-        }
-        .sheet(isPresented: $showDiningLoginView) {
-            DiningLoginNavigationView()
-                .environmentObject(diningAnalyticsViewModel)
+            .alert(isPresented: $showMissingDiningTokenAlert) {
+                showCorrectAlert()
+            }
+            .sheet(isPresented: $showDiningLoginView) {
+                DiningLoginNavigationView()
+                    .environmentObject(diningAnalyticsViewModel)
+            }
+        } else {
+            let dollarXYHistory = Binding(
+                get: {
+                    getSmoothedData(from: diningAnalyticsViewModel.dollarHistory)
+                },
+                // one directional Binding, setter does not work
+                set: {  _ in }
+            )
+            let swipeXYHistory = Binding(
+                get: { getSmoothedData(from: diningAnalyticsViewModel.swipeHistory) },
+                // one directional Binding, setter does not work
+                set: {  _ in }
+            )
+            HStack {
+                if Account.isLoggedIn, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration {
+                    if swipeXYHistory.wrappedValue.isEmpty && dollarXYHistory.wrappedValue.isEmpty {
+                        ZStack {
+                            Image("DiningAnalyticsBackground")
+                                .resizable()
+                                .ignoresSafeArea()
+                            Text("No Dining\nPlan Found\n ")
+                                .multilineTextAlignment(.center)
+                                .font(.system(size: 48, weight: .regular))
+                                .foregroundColor(.black)
+                                .opacity(0.6)
+                        }
+                    } else {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 20) {
+                                Text("Dining Analytics")
+                                    .font(.system(size: 32))
+                                    .bold()
+                                // Only show dollar history view if there is data for the graph
+                                if !dollarXYHistory.wrappedValue.isEmpty {
+                                    CardView {
+                                        PredictionsGraphView(type: "dollars", data: dollarXYHistory, predictedZeroDate: $diningAnalyticsViewModel.dollarPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedDollarSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.dollarAxisLabel, slope: $diningAnalyticsViewModel.dollarSlope)
+                                    }
+                                }
+                                // Only show swipe history view if there is data for the graph
+                                if !swipeXYHistory.wrappedValue.isEmpty {
+                                    CardView {
+                                        PredictionsGraphView(type: "swipes", data: swipeXYHistory, predictedZeroDate: $diningAnalyticsViewModel.swipesPredictedZeroDate, predictedSemesterEndValue: $diningAnalyticsViewModel.predictedSwipesSemesterEndBalance, axisLabelsYX: $diningAnalyticsViewModel.swipeAxisLabel, slope: $diningAnalyticsViewModel.swipeSlope)
+                                    }
+                                }
+                                Spacer()
+                            }
+                            .padding()
+                        }
+                    }
+                }
+            }
+            .task {
+                guard Account.isLoggedIn, KeychainAccessible.instance.getDiningToken() != nil, let diningExpiration = UserDefaults.standard.getDiningTokenExpiration(), Date() <= diningExpiration else {
+                    showMissingDiningTokenAlert = true
+                    return
+                }
+            }
+            .alert(isPresented: $showMissingDiningTokenAlert) {
+                showCorrectAlert()
+            }
+            .sheet(isPresented: $showDiningLoginView) {
+                DiningLoginNavigationView()
+                    .environmentObject(diningAnalyticsViewModel)
+            }
         }
     }
 }

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
@@ -1,0 +1,208 @@
+//
+//  DiningAnalyticsGraph.swift
+//  PennMobile
+//
+//  Created by Jordan H on 1/27/23.
+//  Copyright © 2023 PennLabs. All rights reserved.
+//
+
+import SwiftUI
+import Charts
+
+struct AnalyticsGraph: View {
+    private let graphHeight: CGFloat = 180.0
+    @Binding var data: [DiningAnalyticsBalance]
+    var color: Color = Color.blue
+    var start: Date = Date.startOfSemester
+    var end: Date = Date.endOfSemester
+    var xAxisLabelCount: Int = 5
+    var yAxisLabelCount: Int = 4
+    @Binding var predictedZeroDate: Date
+    @Binding var predictedSemesterEndValue: Double
+    var balanceFormat: String
+    var displayZeroDate: Bool {
+        end >= predictedZeroDate
+    }
+    var predictionLineData: [DiningAnalyticsBalance] {
+        if data.last == nil || data.last!.date < start {
+            return []
+        } else {
+            if displayZeroDate {
+                return [data.last!, DiningAnalyticsBalance(date: predictedZeroDate, balance: 0)]
+            } else {
+                return [data.last!, DiningAnalyticsBalance(date: end, balance: predictedSemesterEndValue)]
+            }
+        }
+    }
+    var maxY: Double {
+        data.max(by: { $0.balance < $1.balance })?.balance ?? 300.0
+    }
+    var labels: ([Date], [Double]) {
+        (getXLabels(xAxisLabelCount: xAxisLabelCount), getYLabels(yAxisLabelCount: yAxisLabelCount))
+    }
+    @State var showInfo = false
+    @State var tapLocation: CGPoint = CGPoint(x: 0.0, y: 0.0)
+    @State var tapDate: Date = Date.startOfSemester
+    @State var tapBalance: Double = 0.0
+    @State var isPrediction: Bool = false
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            ZStack {
+                Chart {
+                    ForEach(data) {
+                        LineMark(
+                            x: .value("Day", $0.date, unit: .day),
+                            y: .value("Balance", $0.balance)
+                        )
+                        .foregroundStyle(color)
+                        .foregroundStyle(by: .value("Type", "Data"))
+                    }
+                    ForEach(predictionLineData) {
+                        LineMark(
+                            x: .value("Day", $0.date, unit: .day),
+                            y: .value("Balance", $0.balance)
+                        )
+                        .foregroundStyle(Color.gray)
+                        .foregroundStyle(by: .value("Type", "Prediction"))
+                        .lineStyle(StrokeStyle(lineWidth: 2, dash: [5]))
+                    }
+                    RuleMark(x: .value("End of Term", end))
+                        .foregroundStyle(Color.red)
+                        .annotation(alignment: .trailing) {
+                            Text("End of Term")
+                                .font(.caption)
+                                .foregroundColor(Color.red)
+                        }
+                    PointMark(x: .value("End of Term", end), y: .value("End of Term", maxY))
+                        .foregroundStyle(Color.red)
+                    if showInfo {
+                        PointMark(x: .value("Tap", tapDate), y: .value("Tap", tapBalance))
+                            .foregroundStyle(isPrediction ? Color.gray : color)
+                    }
+                }
+                .chartLegend(.hidden)
+                .chartYAxis {
+                    AxisMarks(position: .leading, values: labels.1) {
+                        AxisGridLine()
+                        // AxisTick()
+                        AxisValueLabel(anchor: .trailing, collisionResolution: .disabled)
+                    }
+                }
+                .chartYScale(domain: 0...maxY)
+                .chartXAxis {
+                    AxisMarks(values: labels.0) { value in
+                        AxisGridLine()
+                        // AxisTick(centered: true)
+                        AxisValueLabel(anchor: .top, collisionResolution: .disabled) {
+                            Text(axesDateFormatter.string(from: value.as(Date.self)!))
+                        }
+                    }
+                }
+                .chartXScale(domain: start...end)
+                .frame(height: graphHeight)
+                .chartOverlay { proxy in
+                    GeometryReader { geometry in
+                        Rectangle().fill(.clear).contentShape(Rectangle())
+                            .gesture(
+                                DragGesture(minimumDistance: 0)
+                                    .onChanged { value in
+                                        // Convert the gesture location to the coordiante space of the plot area
+                                        let origin = geometry[proxy.plotAreaFrame].origin
+                                        let location = CGPoint(
+                                            x: value.location.x - origin.x,
+                                            y: value.location.y - origin.y
+                                        )
+                                        // Get the x (date) and y (balance) value from the tap location (balance from tap location, not line location
+                                        let (date, _) = proxy.value(at: location, as: (Date, Double).self) ?? (start, 0)
+                                        // Get the actual balance at date, from non predicted data
+                                        var balance = data.last(where: {Calendar.current.isDate($0.date, inSameDayAs: date)})?.balance ?? -1.0
+                                        isPrediction = false
+                                        // Get actual balance at date, from predicted data
+                                        if balance == -1.0 && predictionLineData.count != 0 && predictionLineData[0].date < date {
+                                            // Ensuring prediction line exists and is valid
+                                            if let predStart = proxy.position(for: (x: predictionLineData[0].date, y: predictionLineData[0].balance)),
+                                               let predEnd = proxy.position(for: (x: predictionLineData[1].date, y: predictionLineData[1].balance)) {
+                                                // Get slope of line, and then predicted balance
+                                                let slope = (predEnd.y - predStart.y) / (predEnd.x - predStart.x)
+                                                balance = proxy.value(atY: slope * (location.x - predStart.x) + predStart.y) ?? -1.0
+                                                isPrediction = true
+                                            }
+                                        }
+                                        // Get graph coordinate of balance
+                                        let coordOfBalance = proxy.position(forY: balance) ?? 0.0
+                                        // Check if position is on screen (and balance is valid)
+                                        showInfo = balance != -1.0 && 0 <= location.x && location.x <= proxy.plotAreaSize.width && coordOfBalance >= 0 && coordOfBalance <= proxy.plotAreaSize.height
+                                        // Get pixel position of where to display (relative to whole screen)
+                                        tapLocation = CGPoint(x: value.location.x, y: coordOfBalance + origin.y)
+                                        tapDate = date
+                                        tapBalance = balance
+                                    }
+                                    .onEnded { _ in
+                                        showInfo = false
+                                    }
+                            )
+                    }
+                }
+                if showInfo {
+                    ZoomInfo(location: tapLocation, date: tapDate, balance: tapBalance, balanceFormat: balanceFormat, color: isPrediction ? Color.gray : color)
+                }
+            }
+        }
+    }
+    func getXLabels(xAxisLabelCount: Int = 5) -> [Date] {
+        var xLabels: [Date] = []
+        let semester = start.distance(to: end)
+        let semesterStep = semester / Double(xAxisLabelCount - 1)
+        for i in 0 ..< xAxisLabelCount {
+            let dateForLabel = start.advanced(by: semesterStep * Double(i))
+            xLabels.append(dateForLabel)
+        }
+        return xLabels
+    }
+    func getYLabels(yAxisLabelCount: Int = 4) -> [Double] {
+        var yLabels: [Double] = []
+        let dollarStep = (maxY / Double(yAxisLabelCount - 1))
+        for i in 0 ..< yAxisLabelCount {
+            let yAxisLabel = dollarStep * Double(yAxisLabelCount - i - 1)
+            yLabels.append(yAxisLabel)
+        }
+        return yLabels
+    }
+}
+
+struct ZoomInfo: View {
+    var location: CGPoint
+    var date: Date
+    var balance: Double
+    var balanceFormat: String
+    var color: Color
+    var body: some View {
+        ZStack {
+            // Circle()
+            //     .stroke(color, lineWidth: 4)
+            //     .frame(width: 50, height: 50)
+            // ADD SOME OTHER DESIGN
+            VStack {
+                Text(infoDateFormatter.string(from: date))
+                    .foregroundColor(color)
+                    .font(.caption)
+                Text(String(format: balanceFormat, balance))
+                    .foregroundColor(color)
+                    .font(.caption)
+            }
+        }
+        .position(x: min(location.x + 25, UIScreen.main.bounds.size.width - 75), y: location.y - 25)
+    }
+}
+
+let axesDateFormatter: DateFormatter = {
+    let result = DateFormatter()
+    result.dateFormat = "M/d"
+    return result
+}()
+
+let infoDateFormatter: DateFormatter = {
+    let result = DateFormatter()
+    result.dateFormat = "MMM. d"
+    return result
+}()

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
@@ -9,6 +9,13 @@
 import SwiftUI
 import Charts
 
+/*
+Things we can remove once we switch to only supporting iOS 16:
+    - Everything in PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/ except DiningAnalyticsGraph.swift and DiningAnalyticsGraphBox.swift
+    - Everything in the not iOS 16 else statement in PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
+    - axisLabels calculations from Shared/Dining/DiningAnalyticsViewModel.swift
+*/
+
 struct AnalyticsGraph: View {
     private let graphHeight: CGFloat = 180.0
     @Binding var data: [DiningAnalyticsBalance]

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
@@ -14,6 +14,7 @@ Things we can remove once we switch to only supporting iOS 16:
     - Everything in PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/ except DiningAnalyticsGraph.swift and DiningAnalyticsGraphBox.swift
     - Everything in the not iOS 16 else statement in PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
     - axisLabels calculations from Shared/Dining/DiningAnalyticsViewModel.swift
+    - getSmoothedData in PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
 */
 
 struct AnalyticsGraph: View {

--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraphBox.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraphBox.swift
@@ -1,0 +1,72 @@
+//
+//  DiningAnalyticsGraphBox.swift
+//  PennMobile
+//
+//  Created by Jordan H on 1/30/23.
+//  Copyright © 2023 PennLabs. All rights reserved.
+//
+
+import SwiftUI
+
+struct GraphView: View {
+    enum BalanceType {
+        case swipes
+        case dollars
+    }
+    var type: BalanceType
+    @Binding var data: [DiningAnalyticsBalance]
+    var start: Date = Date.startOfSemester
+    var end: Date = Date.endOfSemester
+    @Binding var predictedZeroDate: Date
+    @Binding var predictedSemesterEndValue: Double
+    var displayZeroDate: Bool {
+        end >= predictedZeroDate
+    }
+    var color: Color {
+        type == .swipes ? .blue : .green
+    }
+    var balanceFormat: String {
+        type == .swipes ? "%.0f Swipes" : "$%.2f"
+    }
+    var helpText: String {
+        if displayZeroDate {
+            return "Based on your current balance and past behavior, we project you'll run out on this date."
+        } else {
+            return "Based on your past behavior, we project you'll end the semester with \(type == .swipes ? "swipes" : "dollars") to spare."
+        }
+    }
+    var formattedZeroDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM. d"
+        return formatter.string(from: predictedZeroDate)
+    }
+    var body: some View {
+        VStack(alignment: .leading) {
+            Group {
+                CardHeaderTitleView(color: color, icon: .predictions, title: "\(type == .swipes ? "Swipes" : "Dining Dollars") Predictions")
+            }
+            Divider()
+                .padding([.top, .bottom])
+            AnalyticsGraph(data: $data, color: color, start: start, end: end, predictedZeroDate: $predictedZeroDate, predictedSemesterEndValue: $predictedSemesterEndValue, balanceFormat: balanceFormat)
+            Divider()
+                .padding([.top, .bottom])
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(displayZeroDate ? ("Out of \(type == .swipes ? "Swipes" : "Dollars")") : "Extra Balance")
+                        .font(.caption)
+                    Text(displayZeroDate ? "\(formattedZeroDate)" : String(format: balanceFormat, predictedSemesterEndValue))
+                        .font(Font.system(size: 21, weight: .bold, design: .rounded))
+                    Spacer()
+                }
+                .padding(.trailing)
+                VStack {
+                    Text(helpText)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                    Spacer()
+                }
+            }.frame(height: 60)
+        }
+        .padding()
+    }
+}

--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/MenuDisclosureGroup.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/MenuDisclosureGroup.swift
@@ -34,7 +34,6 @@ struct DiningStationRow: View {
                 .font(Font.system(size: 17))
                 .padding()
                 .background(Color.uiCardBackground.cornerRadius(8))
-                .shadow(color: Color.black.opacity(0.2), radius: 4, x: 2, y: 2)
             if isExpanded {
                 VStack {
                     ForEach(diningStation.items, id: \.self) { diningStationItem in

--- a/Shared/Dining/DiningAnalyticsViewModel.swift
+++ b/Shared/Dining/DiningAnalyticsViewModel.swift
@@ -10,9 +10,10 @@ import Foundation
 import SwiftUI
 import WidgetKit
 
-struct DiningAnalyticsBalance: Codable, Equatable {
+struct DiningAnalyticsBalance: Codable, Equatable, Identifiable {
     let date: Date
     let balance: Double
+    var id: Date {date}
 }
 
 extension DiningAnalyticsBalance: Comparable {


### PR DESCRIPTION
The functionality is complete, and it works well. Then only thing I think we need to change is how the display actually looks. We could make it display above/below the line depending on the quadrant, add a transparent background to the text, or anything else etc. We should probably get a designer to plan this, but I think it looks good for now.

Also, the new graphs only work in iOS 16, but only 75% of our users use iOS 16 currently. Because of this, I left all of the old code in and only display the new graph if iOS 16 is being used. Therefore all of the old code is still actually in use, and cannot be deleted yet. However, after more people switch over to iOS 16, we can delete every other file in ./PredictionsGraph/, and DiningAnalyticsView can be vastly simplified.

https://user-images.githubusercontent.com/35184414/216840137-06e541fe-e423-4330-8a7e-8c2868345840.mov
