### PR TITLE
Fix compiling on Xcode 14.3 beta

### DIFF
--- a/Shared/Courses/ScheduleView.swift
+++ b/Shared/Courses/ScheduleView.swift
@@ -142,7 +142,8 @@ struct ScheduleView: View {
                             Group {
                                 if time % 60 == 0 {
                                     let components = DateComponents(calendar: calendar, timeZone: timezone, hour: time / 60)
-                                    if let date = calendar.date(from: components), let str = hourFormatter.string(from: date) {
+                                    if let date = calendar.date(from: components) {
+                                        let str = hourFormatter.string(from: date)
                                         Text(str).font(.caption)
                                     } else {
                                         Spacer()


### PR DESCRIPTION
The beta version of Xcode seems to not like optional bindings that aren't necessary. This PR fixes that.

As an aside, anyone using Xcode 14.3 will need to update Kingfisher to the latest version, but that is not included in this PR.
