### PR TITLE
Fixed bug with missing dining data on graph

### DIFF
--- a/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Insights/PredictionsGraph/DiningAnalyticsGraph.swift
@@ -115,10 +115,10 @@ struct AnalyticsGraph: View {
                                         // Get the x (date) and y (balance) value from the tap location (balance from tap location, not line location
                                         let (date, _) = proxy.value(at: location, as: (Date, Double).self) ?? (start, 0)
                                         // Get the actual balance at date, from non predicted data
-                                        var balance = data.last(where: {Calendar.current.isDate($0.date, inSameDayAs: date)})?.balance ?? -1.0
+                                        var balance = data.last(where: {$0.date <= date})?.balance ?? -1.0
                                         isPrediction = false
                                         // Get actual balance at date, from predicted data
-                                        if balance == -1.0 && predictionLineData.count != 0 && predictionLineData[0].date < date {
+                                        if predictionLineData.count != 0 && predictionLineData[0].date < date {
                                             // Ensuring prediction line exists and is valid
                                             if let predStart = proxy.position(for: (x: predictionLineData[0].date, y: predictionLineData[0].balance)),
                                                let predEnd = proxy.position(for: (x: predictionLineData[1].date, y: predictionLineData[1].balance)) {

--- a/Shared/Dining/DiningAnalyticsViewModel.swift
+++ b/Shared/Dining/DiningAnalyticsViewModel.swift
@@ -98,6 +98,7 @@ class DiningAnalyticsViewModel: ObservableObject {
     }
 
     func populateAxesAndPredictions() {
+        filterData()
         guard let lastDollarBalance = self.dollarHistory.last,
               let lastSwipeBalance = self.swipeHistory.last else {
             return
@@ -136,6 +137,23 @@ class DiningAnalyticsViewModel: ObservableObject {
         self.swipesPredictedZeroDate = swipePredictions.predictedZeroDate
         self.predictedSwipesSemesterEndBalance = swipePredictions.predictedEndBalance
         self.swipeAxisLabel = self.getAxisLabelsYX(from: self.swipeHistory)
+    }
+    
+    func filterData() {
+        if self.dollarHistory.count >= 2 {
+            for i in 1..<(self.dollarHistory.count - 1) {
+                if self.dollarHistory[i].balance == 0 && self.dollarHistory[i - 1].balance > 0 && self.dollarHistory[i + 1].balance > 0 {
+                    self.dollarHistory.remove(at: i)
+                }
+            }
+        }
+        if self.swipeHistory.count >= 2 {
+            for i in 1..<(self.swipeHistory.count - 1) {
+                if self.swipeHistory[i].balance == 0 && self.swipeHistory[i - 1].balance > 0 && self.swipeHistory[i + 1].balance > 0 {
+                    self.swipeHistory.remove(at: i)
+                }
+            }
+        }
     }
 
     func getPredictions(firstBalance: DiningAnalyticsBalance, lastBalance: DiningAnalyticsBalance, maxBalance: DiningAnalyticsBalance) -> (slope: Double, predictedZeroDate: Date, predictedEndBalance: Double) {


### PR DESCRIPTION
Fixes issue #452

On Feb. 13 (and I think maybe 15th), some people have missing dining data. Some people literally don't have data for this day, while others have $0. This patch tries to remove outliers by removing all days where the balance is 0, but the day before and day after have positive balance. Note that this could be incorrect for people who refill their balances the same day they run out (which we assume is no one).

Also, now on the graph, if there is missing data, instead of nothing showing up, it displays the balance from the most recent day beforehand.