### PR TITLE
Show dates on dining analytics widget

### DIFF
--- a/Widget/Dining/DiningAnalyticsHomeWidget.swift
+++ b/Widget/Dining/DiningAnalyticsHomeWidget.swift
@@ -67,16 +67,24 @@ extension DiningAnalyticsMeterType {
 }
 
 extension DiningAnalyticsAuxiliaryStatistic {
-    func getMetric<Balance: AdditiveArithmetic & Comparable>(in balance: BalanceDetails<Balance>) -> Balance {
+    enum MetricResult<Balance: AdditiveArithmetic & Comparable> {
+        case amount(Balance)
+        case date(Date)
+    }
+    
+    func getMetric<Balance: AdditiveArithmetic & Comparable>(in balance: BalanceDetails<Balance>) -> MetricResult<Balance> {
         switch self {
         case .unknown, .projectedEnd:
-            return balance.projectedEnd
+            if let date = balance.projectedEndDate {
+                return .date(date)
+            }
+            return .amount(balance.projectedEnd)
         case .remaining:
-            return balance.remaining
+            return .amount(balance.remaining)
         case .used:
-            return balance.used
+            return .amount(balance.used)
         case .total:
-            return balance.total
+            return .amount(balance.total)
         }
     }
 
@@ -91,6 +99,33 @@ extension DiningAnalyticsAuxiliaryStatistic {
         case .total:
             return "Total"
         }
+    }
+}
+
+private func formatSwipes(statistic: DiningAnalyticsAuxiliaryStatistic, in balance: BalanceDetails<Int>, includeUnits: Bool = false) -> LocalizedStringKey {
+    switch statistic.getMetric(in: balance) {
+    case .amount(let amount):
+        if includeUnits {
+            // Auto-inflection is genuinely an amazing feature
+            return "^[\(amount) swipe](inflect: true)"
+        } else {
+            return "\(amount)"
+        }
+    case .date(let date):
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return "\(date, formatter: formatter)"
+    }
+}
+
+private func formatDollars(statistic: DiningAnalyticsAuxiliaryStatistic, in balance: BalanceDetails<Double>) -> LocalizedStringKey {
+    switch statistic.getMetric(in: balance) {
+    case .amount(let amount):
+        return "\(amount, format: .currency(code: "USD"))"
+    case .date(let date):
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return "\(date, formatter: formatter)"
     }
 }
 
@@ -140,7 +175,7 @@ private struct DiningAnalyticsSmall: View {
                                 (
                                     Text("\(Int(metric))").fontWeight(.bold) +
                                     Text(".\(String(format: "%02d", Int(metric * 100) % 100))").fontWeight(.medium).font(.caption2)
-                                ).lineLimit(1).privacySensitive()
+                                ).privacySensitive()
                             } else {
                                 Text("\(Int(metric))").fontWeight(.bold).multilineTextAlignment(.center).privacySensitive()
                             }
@@ -153,9 +188,10 @@ private struct DiningAnalyticsSmall: View {
             .padding(.bottom, 4)
             Text(configuration.auxiliaryStatistic.label).font(.caption2).foregroundColor(.secondary).unredacted()
             HStack(spacing: 5) {
-                let swipes = configuration.auxiliaryStatistic.getMetric(in: swipes)
-                let dollars = configuration.auxiliaryStatistic.getMetric(in: dollars)
-                Text("\(swipes) \(swipes == 1 || swipes == -1 ? "swipe" : "swipes"), \(dollars, format: .currency(code: "USD"))").fontWeight(.medium).font(.caption).privacySensitive()
+                // I hate this but LocalizedStringResource isn't available until iOS 16 🙃
+                let swipes = formatSwipes(statistic: configuration.auxiliaryStatistic, in: swipes, includeUnits: true)
+                let dollars = formatDollars(statistic: configuration.auxiliaryStatistic, in: dollars)
+                (Text(swipes) + Text(", ") + Text(dollars)).fontWeight(.medium).font(.caption).privacySensitive()
             }.multilineTextAlignment(.center)
         }
     }
@@ -187,7 +223,7 @@ private struct DiningAnalyticsSummary: View {
                                 (
                                     Text("\(Int(metric))").fontWeight(.bold).font(.title2) +
                                     Text(".\(String(format: "%02d", Int(metric * 100) % 100))").fontWeight(.medium)
-                                ).lineLimit(1).privacySensitive()
+                                ).privacySensitive()
                             } else {
                                 Text("\(Int(metric))").fontWeight(.bold).font(.title2).multilineTextAlignment(.center).privacySensitive()
                             }
@@ -198,15 +234,15 @@ private struct DiningAnalyticsSummary: View {
             }.layoutPriority(2)
             Spacer(minLength: 16)
             VStack(alignment: .leading, spacing: 10) {
-                Text(configuration.auxiliaryStatistic.label).fontWeight(.medium).foregroundColor(.secondary).font(.caption)
+                Text(configuration.auxiliaryStatistic.label).fontWeight(.medium).foregroundColor(.secondary).font(.caption).lineLimit(2)
                 VStack(alignment: .leading) {
                     Text("Swipes").fontWeight(.medium).font(.caption)
-                    Text("\(configuration.auxiliaryStatistic.getMetric(in: swipes))").fontWeight(.bold)
+                    Text(formatSwipes(statistic: configuration.auxiliaryStatistic, in: swipes, includeUnits: false)).fontWeight(.bold)
                 }
 
                 VStack(alignment: .leading) {
                     Text("Dollars").fontWeight(.medium).font(.caption)
-                    Text("\(configuration.auxiliaryStatistic.getMetric(in: dollars), format: .currency(code: "USD"))").fontWeight(.bold)
+                    Text(formatDollars(statistic: configuration.auxiliaryStatistic, in: dollars)).fontWeight(.bold)
                 }
             }
         }
@@ -234,6 +270,7 @@ struct DiningAnalyticsHomeWidgetView: View {
                 (Text("Go to ") + Text("Dining › Analytics").fontWeight(.bold) + Text(" to use this widget.")).multilineTextAlignment(.center).padding()
             }
         }
+        .lineLimit(1)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(entry.configuration.background)
     }

--- a/Widget/Dining/DiningAnalyticsProvider.swift
+++ b/Widget/Dining/DiningAnalyticsProvider.swift
@@ -13,6 +13,7 @@ struct BalanceDetails<Balance: AdditiveArithmetic & Comparable> {
     var remaining: Balance
     var total: Balance
     var projectedEnd: Balance
+    var projectedEndDate: Date?
 
     var used: Balance {
         max(.zero, total - remaining)
@@ -67,6 +68,9 @@ private func refresh() async {
     let totalSwipes = max(remainingSwipes, model.swipeHistory.max().map { Int($0.balance) } ?? 0)
     let projectedSwipes = Int(model.predictedSwipesSemesterEndBalance)
     cachedSwipes = BalanceDetails(remaining: remainingSwipes, total: totalSwipes, projectedEnd: projectedSwipes)
+    if projectedSwipes <= 0 {
+        cachedSwipes?.projectedEndDate = model.swipesPredictedZeroDate
+    }
 
     guard let remainingDollars = Double(balances.diningDollars) else {
         return
@@ -74,6 +78,9 @@ private func refresh() async {
     let totalDollars = max(remainingDollars, model.dollarHistory.max()?.balance ?? 0)
     let projectedDollars = model.predictedDollarSemesterEndBalance
     cachedDollars = BalanceDetails(remaining: remainingDollars, total: totalDollars, projectedEnd: projectedDollars)
+    if projectedDollars <= 0 {
+        cachedDollars?.projectedEndDate = model.dollarPredictedZeroDate
+    }
 }
 
 private func snapshot<Configuration>(configuration: Configuration) async -> DiningAnalyticsEntry<Configuration> {


### PR DESCRIPTION
Shows dates instead of negative numbers when a user is projected to run out of swipes and/or dollars. Some examples:

![IMG_3502](https://user-images.githubusercontent.com/7005789/219816626-45c4e1c3-cf54-449f-bad9-1d3d43dbea75.jpeg)

![IMG_3503](https://user-images.githubusercontent.com/7005789/219816635-3c542f9b-6a4f-4880-8ca8-82c6b2fccd64.jpeg)