### PR TITLE
Deleted unused helper function

### DIFF
--- a/PennMobile/Setup + Navigation/AppDelegate.swift
+++ b/PennMobile/Setup + Navigation/AppDelegate.swift
@@ -113,11 +113,6 @@ extension AppDelegate {
     }
 }
 
-// Helper function inserted by Swift 4.2 migrator.
-private func convertFromUIBackgroundTaskIdentifier(_ input: UIBackgroundTaskIdentifier) -> Int {
-	return input.rawValue
-}
-
 // Migration of data to group container
 func migrateDataToGroupContainer() {
     if Storage.migrate(fileName: Course.cacheFileName, of: [Course].self, from: .caches, to: .groupCaches) {


### PR DESCRIPTION
Deleted convertFromUIBackgroundTaskIdentifier helper function (one liner) automatically generated by Swift 4.2 migrator 

(Anthony told me I could do this so blame him if this is bad)