### PR TITLE
Switch /token endpoint to pennmobile.org

### DIFF
--- a/PennMobile/Auth/OAuth2NetworkManager.swift
+++ b/PennMobile/Auth/OAuth2NetworkManager.swift
@@ -126,7 +126,7 @@ extension OAuth2NetworkManager {
                         return
                     } else if httpResponse.statusCode == 400 {
                         let json = JSON(data)
-                        if json["error"].stringValue == "invalid_grant" {
+                        if json["detail"].stringValue == "Invalid parameters" {
                             // This refresh token is invalid.
                             if let accessToken = self.currentAccessToken, refreshToken != self.getRefreshToken() {
                                 // Access token has been refreshed in another network call while we were waiting and current refresh token is not the same one we used

--- a/PennMobile/Auth/OAuth2NetworkManager.swift
+++ b/PennMobile/Auth/OAuth2NetworkManager.swift
@@ -39,7 +39,7 @@ class OAuth2NetworkManager: NSObject {
 // MARK: - Initiate Authentication
 extension OAuth2NetworkManager {
     static let tokenURL = URL(string: "https://pennmobile.org/api/accounts/token/")!
-    
+
     /// Input: One-time code from login
     /// Output: Temporary access token
     /// Saves refresh token in keychain for future use

--- a/PennMobile/Auth/OAuth2NetworkManager.swift
+++ b/PennMobile/Auth/OAuth2NetworkManager.swift
@@ -38,12 +38,13 @@ class OAuth2NetworkManager: NSObject {
 
 // MARK: - Initiate Authentication
 extension OAuth2NetworkManager {
+    static let tokenURL = URL(string: "https://pennmobile.org/api/accounts/token/")!
+    
     /// Input: One-time code from login
     /// Output: Temporary access token
     /// Saves refresh token in keychain for future use
     func initiateAuthentication(code: String, codeVerifier: String, _ callback: @escaping (_ accessToken: AccessToken?) -> Void) {
-        let url = URL(string: "https://platform.pennlabs.org/accounts/token/")!
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: Self.tokenURL)
         request.httpMethod = "POST"
 
         let params = [
@@ -98,8 +99,7 @@ extension OAuth2NetworkManager {
             return
         }
 
-        let url = URL(string: "https://platform.pennlabs.org/accounts/token/")!
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: Self.tokenURL)
         request.httpMethod = "POST"
 
         let params = [


### PR DESCRIPTION
This PR switches the token route to the Penn Mobile backend (as advised by @judtinzhang), which lets us do more interesting things on the Penn Mobile side.

Haven't thoroughly tested for regressions, but it looks like thing aren't entirely dead from cursory testing., The one wildcard is course alerts (which uses some sort of CSRF thing), but it's unclear whether that worked in the first place.
