### PR TITLE
Make widgets compatible with the iOS 17 SDK

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		6CFA06F826E8355400944B8E /* HomeFeatureCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFA06F726E8355400944B8E /* HomeFeatureCellItem.swift */; };
 		8766844128CBE907005CAD32 /* NativeNewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8766844028CBE907005CAD32 /* NativeNewsViewController.swift */; };
 		87FE6479290EE4BE00AFADF6 /* NotificationAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FE6478290EE4BE00AFADF6 /* NotificationAPIModel.swift */; };
+		890DDBC62AA2E4B6006815A3 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890DDBC42AA2E499006815A3 /* ViewExtensions.swift */; };
 		891CCBAB28FC97E800A48903 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = 891CCBAA28FC97E800A48903 /* .gitkeep */; };
 		89325390290F98E7006EE62C /* ConfigurationRepresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8932538E290F98BD006EE62C /* ConfigurationRepresenting.swift */; };
 		89325393291025A8006EE62C /* WidgetBackgroundTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893253912910249B006EE62C /* WidgetBackgroundTypeExtensions.swift */; };
@@ -562,6 +563,7 @@
 		72787B1E070BFCDF84D8C3CA /* Pods-PennMobile.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PennMobile.debug.xcconfig"; path = "Target Support Files/Pods-PennMobile/Pods-PennMobile.debug.xcconfig"; sourceTree = "<group>"; };
 		8766844028CBE907005CAD32 /* NativeNewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeNewsViewController.swift; sourceTree = "<group>"; };
 		87FE6478290EE4BE00AFADF6 /* NotificationAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAPIModel.swift; sourceTree = "<group>"; };
+		890DDBC42AA2E499006815A3 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
 		891CCBAA28FC97E800A48903 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		8932538E290F98BD006EE62C /* ConfigurationRepresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationRepresenting.swift; sourceTree = "<group>"; };
 		893253912910249B006EE62C /* WidgetBackgroundTypeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackgroundTypeExtensions.swift; sourceTree = "<group>"; };
@@ -1428,6 +1430,7 @@
 				8932693928FC75A5003D4BF9 /* WidgetBundle.swift */,
 				8932538E290F98BD006EE62C /* ConfigurationRepresenting.swift */,
 				893253912910249B006EE62C /* WidgetBackgroundTypeExtensions.swift */,
+				890DDBC42AA2E499006815A3 /* ViewExtensions.swift */,
 				89EA261F290EE39E008F26CF /* Courses */,
 				89CA727129171E2400CF72FE /* Dining */,
 				8932693F28FC75A6003D4BF9 /* Assets.xcassets */,
@@ -2497,6 +2500,7 @@
 				89EA2622290EE3FD008F26CF /* CoursesProvider.swift in Sources */,
 				89CA72852917209000CF72FE /* DiningMenu.swift in Sources */,
 				89CA727F2917202700CF72FE /* DiningAPI.swift in Sources */,
+				890DDBC62AA2E4B6006815A3 /* ViewExtensions.swift in Sources */,
 				89CA727A2917201C00CF72FE /* Extensions.swift in Sources */,
 				89CA729829175C9C00CF72FE /* MeterView.swift in Sources */,
 				89CA72832917209000CF72FE /* DiningToken.swift in Sources */,

--- a/Widget/Courses/CoursesDayWidget.swift
+++ b/Widget/Courses/CoursesDayWidget.swift
@@ -173,7 +173,7 @@ struct CoursesDayWidgetView: View {
                 Text("Unsupported")
             }
         }
-        .background(entry.configuration.background)
+        .widgetBackground(entry.configuration.background)
     }
 }
 
@@ -188,6 +188,7 @@ struct CoursesDayWidget: Widget {
         .configurationDisplayName("Today's Classes")
         .description("Your upcoming classes for the day, at a glance.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .contentMarginsDisabled()
     }
 }
 

--- a/Widget/Dining/DiningAnalyticsHomeWidget.swift
+++ b/Widget/Dining/DiningAnalyticsHomeWidget.swift
@@ -237,12 +237,12 @@ private struct DiningAnalyticsSummary: View {
                 Text(configuration.auxiliaryStatistic.label).fontWeight(.medium).foregroundColor(.secondary).font(.caption).lineLimit(2)
                 VStack(alignment: .leading) {
                     Text("Swipes").fontWeight(.medium).font(.caption)
-                    Text(formatSwipes(statistic: configuration.auxiliaryStatistic, in: swipes, includeUnits: false)).fontWeight(.bold)
+                    Text(formatSwipes(statistic: configuration.auxiliaryStatistic, in: swipes, includeUnits: false)).fontWeight(.bold).fixedSize()
                 }
 
                 VStack(alignment: .leading) {
                     Text("Dollars").fontWeight(.medium).font(.caption)
-                    Text(formatDollars(statistic: configuration.auxiliaryStatistic, in: dollars)).fontWeight(.bold)
+                    Text(formatDollars(statistic: configuration.auxiliaryStatistic, in: dollars)).fontWeight(.bold).fixedSize()
                 }
             }
         }
@@ -261,18 +261,18 @@ struct DiningAnalyticsHomeWidgetView: View {
                 case .systemSmall:
                     DiningAnalyticsSmall(swipes: swipes, dollars: dollars, configuration: entry.configuration)
                 case .systemMedium:
-                    DiningAnalyticsSummary(swipes: swipes, dollars: dollars, configuration: entry.configuration)
-                        .padding(.horizontal, 20)
+                    DiningAnalyticsSummary(swipes: swipes, dollars: dollars, configuration: entry.configuration).widgetPadding(.horizontal, 20)
                 default:
                     Text("Unsupported")
                 }
             } else {
-                (Text("Go to ") + Text("Dining › Analytics").fontWeight(.bold) + Text(" to use this widget.")).multilineTextAlignment(.center).padding()
+                (Text("Go to ") + Text("Dining › Analytics").fontWeight(.bold) + Text(" to use this widget.")).multilineTextAlignment(.center)
+                    .widgetPadding()
             }
         }
         .lineLimit(1)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(entry.configuration.background)
+        .widgetBackground(entry.configuration.background)
     }
 }
 

--- a/Widget/ViewExtensions.swift
+++ b/Widget/ViewExtensions.swift
@@ -1,0 +1,50 @@
+//
+//  ViewExtensions.swift
+//  PennMobile
+//
+//  Created by Anthony Li on 9/1/23.
+//  Copyright © 2023 PennLabs. All rights reserved.
+//
+
+import SwiftUI
+
+struct WidgetBackground<Style: ShapeStyle>: ViewModifier {
+    var background: Style
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            return content.containerBackground(background, for: .widget)
+        } else {
+            return content.background(background)
+        }
+    }
+}
+
+struct WidgetPadding: ViewModifier {
+    var edges: Edge.Set
+    var length: CGFloat?
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            return content
+        } else {
+            return content.padding(edges, length)
+        }
+    }
+}
+
+extension View {
+    /// Applies a widget background, dynamically choosing between containerBackground on iOS 17
+    /// and a standard background on iOS 16.
+    func widgetBackground<Style: ShapeStyle>(_ background: Style) -> some View {
+        modifier(WidgetBackground(background: background))
+    }
+    
+    /// Applies padding to the view on iOS 16 or below.
+    ///
+    /// The system will automatically apply padding on iOS 17, so we ignore these values
+    /// if we're running on iOS 17 or later.
+    func widgetPadding(_ edges: Edge.Set = .all, _ length: CGFloat? = nil) -> some View {
+        modifier(WidgetPadding(edges: edges, length: length))
+    }
+}

--- a/Widget/WidgetBackgroundTypeExtensions.swift
+++ b/Widget/WidgetBackgroundTypeExtensions.swift
@@ -8,17 +8,15 @@
 
 import SwiftUI
 
-extension WidgetBackgroundType: View {
-    public var body: some View {
-        Group {
-            switch self {
-            case .unknown, .whiteGray:
-                Color.uiCardBackground
-            case .whiteBlack:
-                Color("White/Black")
-            case .gradient:
-                LinearGradient(colors: [Color("Gradient1"), Color("Gradient2")], startPoint: .bottomLeading, endPoint: .top)
-            }
+extension WidgetBackgroundType: ShapeStyle, @unchecked Sendable {
+    public func resolve(in environment: EnvironmentValues) -> some ShapeStyle {
+        switch self {
+        case .unknown, .whiteGray:
+            return AnyShapeStyle(Color.uiCardBackground)
+        case .whiteBlack:
+            return AnyShapeStyle(Color("White/Black"))
+        case .gradient:
+            return AnyShapeStyle(LinearGradient(colors: [Color("Gradient1"), Color("Gradient2")], startPoint: .bottomLeading, endPoint: .top))
         }
     }
 


### PR DESCRIPTION
Applies `containerBackground` modifiers as necessary to make sure our widgets don't end up looking like this when we compile for iOS 17:

![A widget saying "Please adopt containerBackground API"](https://github.com/pennlabs/penn-mobile-ios/assets/7005789/797594df-8406-43cb-87de-9051d026ea2c)

Also tweaks widget paddings to use system-provided ones when possible.

As an aside, this enables StandBy support for all of our widgets!