### PR TITLE
Bump Firebase to v10

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -3124,7 +3124,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.6.1;
+				minimumVersion = 10.0.0;
 			};
 		};
 		F213CCE023C3EE3E000AD90F /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {


### PR DESCRIPTION
As discovered by @george-botros, this fixes an issue where the build could fail with:

> error: Info.plist Error Unable to process Info.plist at path /Users/user/Library/Developer/Xcode/DerivedData/PennMobile-blah/Build/Products/Debug-iphonesimulator/PennMobile.app/Info.plist
