### PR TITLE
fix: Fixed dining venues sometimes not appearing (hopefully)

### DIFF
--- a/PennMobile/Dining/SwiftUI/DiningViewModelSwiftUI.swift
+++ b/PennMobile/Dining/SwiftUI/DiningViewModelSwiftUI.swift
@@ -21,13 +21,20 @@ class DiningViewModelSwiftUI: ObservableObject {
     @Published var alertType: NetworkingError?
 
     @Published var diningBalance = (try? Storage.retrieveThrowing(DiningBalance.directory, from: .groupCaches, as: DiningBalance.self)) ?? DiningBalance(date: Date.dayOfMonthFormatter.string(from: Date()), diningDollars: "0.0", regularVisits: 0, guestVisits: 0, addOnVisits: 0)
+
+    var areAllVenuesEmpty: Bool {
+        return diningVenues.allSatisfy { _, venues in
+            venues.isEmpty
+        }
+    }
+
     // MARK: - Venue Methods
     let ordering: [VenueType] = [.dining, .retail]
 
     func refreshVenues() async {
         let lastRequest = UserDefaults.standard.getLastDiningHoursRequest()
         // Sometimes when building the app, dining venue list is empty, but because it has refreshed within the day, it does not refresh again. Now, refreshes if the list of venues is completely empty
-        if lastRequest == nil || !lastRequest!.isToday || areAllVenuesEmpty(diningVenues: diningVenues) {
+        if lastRequest == nil || !lastRequest!.isToday || areAllVenuesEmpty {
             self.diningVenuesIsLoading = true
             let result = await DiningAPI.instance.fetchDiningHours()
             switch result {
@@ -43,12 +50,6 @@ class DiningViewModelSwiftUI: ObservableObject {
             }
 
             self.diningVenuesIsLoading = false
-        }
-    }
-
-    func areAllVenuesEmpty(diningVenues: [VenueType: [DiningVenue]]) -> Bool {
-        return diningVenues.allSatisfy { _, venues in
-            venues.isEmpty
         }
     }
 

--- a/PennMobile/Dining/SwiftUI/DiningViewModelSwiftUI.swift
+++ b/PennMobile/Dining/SwiftUI/DiningViewModelSwiftUI.swift
@@ -27,7 +27,7 @@ class DiningViewModelSwiftUI: ObservableObject {
     func refreshVenues() async {
         let lastRequest = UserDefaults.standard.getLastDiningHoursRequest()
         // Sometimes when building the app, dining venue list is empty, but because it has refreshed within the day, it does not refresh again. Now, refreshes if the list of venues is completely empty
-        if lastRequest == nil || !lastRequest!.isToday || diningVenues.isEmpty {
+        if lastRequest == nil || !lastRequest!.isToday || areAllVenuesEmpty(diningVenues: diningVenues) {
             self.diningVenuesIsLoading = true
             let result = await DiningAPI.instance.fetchDiningHours()
             switch result {
@@ -43,6 +43,12 @@ class DiningViewModelSwiftUI: ObservableObject {
             }
 
             self.diningVenuesIsLoading = false
+        }
+    }
+
+    func areAllVenuesEmpty(diningVenues: [VenueType: [DiningVenue]]) -> Bool {
+        return diningVenues.allSatisfy { _, venues in
+            venues.isEmpty
         }
     }
 


### PR DESCRIPTION
As reported on [Airtable](https://airtable.com/appTHcLDue56TbPL4/tblJYBj92x5vmyHzW/viw12ToU39Gcym38M/recOox5W7NtiUt1lz?blocks=hide), sometimes dining venues do not load. This problem was attempted to be fixed by checking if the list of dining venues is empty, and, if so, refreshing. However, the implementation of this fix was incorrect. The dining venues list is guaranteed to be nonempty. If it is contains no _venues_, it will have two empty arrays. That is, diningVenues will equal `[PennMobileShared.VenueType.dining: [], PennMobileShared.VenueType.retail: []]` but diningVenues.isEmpty will be false. This PR fixes this implementation by checking if each category is empty. 