### PR TITLE
Force LaundryLiveActivity to be in dark mode

### DIFF
--- a/Widget/LaundryLiveActivity.swift
+++ b/Widget/LaundryLiveActivity.swift
@@ -72,6 +72,7 @@ struct LaundryLiveActivity: Widget {
     var body: some WidgetConfiguration {
         return ActivityConfiguration(for: LaundryAttributes.self) { context in
             LaundryLiveActivityView(attributes: context.attributes)
+                .environment(\.colorScheme, .dark)
                 .padding(24)
                 .activityBackgroundTint(Color("liveActivityBackground"))
                 .activitySystemActionForegroundColor(context.attributes.machine.iconColor)


### PR DESCRIPTION
This PR forces the laundry live activity to render in dark mode. Previously, the text would render in black in light mode, but this behavior would only occur on certain iOS versions (I'm able to reproduce it on iOS 17.1, but not on iPadOS 17.0.3, for example.)
