### PR TITLE
Fix course metadata not populating

### DIFF
--- a/PennMobile/Courses/Models/CoursesViewModel.swift
+++ b/PennMobile/Courses/Models/CoursesViewModel.swift
@@ -88,7 +88,7 @@ extension Course {
             meetingTimes = nil
         }
 
-        self.init(crn: crn, code: code, title: title, section: section, instructors: instructors, startDate: startDate, endDate: endDate, meetingTimes: meetingTimes)
+        self.init(crn: crn, code: code, title: title, section: section, instructors: instructors, location: location, startDate: startDate, endDate: endDate, meetingTimes: meetingTimes)
     }
 }
 

--- a/PennMobileShared/Courses/Course.swift
+++ b/PennMobileShared/Courses/Course.swift
@@ -86,10 +86,10 @@ public struct Course: Codable {
         self.code = code
         self.title = title
         self.section = section
-        self.instructors = []
+        self.instructors = instructors
         self.location = location
-        self.startDate = Date.distantPast
-        self.endDate = Date.distantFuture
+        self.startDate = startDate
+        self.endDate = endDate
         self.meetingTimes = meetingTimes
     }
 }


### PR DESCRIPTION
Fixes regressions from #475 that could cause the course schedule view to display courses from all semesters at once and without locations
