### PR TITLE
Upsert Path Registration in PCP upon fetching courses from Path

### DIFF
--- a/PennMobile/Auth/PennLoginController.swift
+++ b/PennMobile/Auth/PennLoginController.swift
@@ -76,28 +76,24 @@ class PennLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate 
                 // Webview has redirected to desired site.
                 self.handleSuccessfulNavigation(webView, decisionHandler: decisionHandler)
             } else {
-                if url.absoluteString.contains("password") {
-                    webView.evaluateJavaScript("document.getElementById('pennname').value;") { (result, _) in
-                        if let pennkey = result as? String {
-                            webView.evaluateJavaScript("document.getElementById('password').value;") { (result, _) in
-                                if let password = result as? String {
-                                    if !pennkey.isEmpty && !password.isEmpty {
-                                        self.pennkey = pennkey
-                                        self.password = password
-                                        if pennkey == "root" && password == "root" {
-                                            self.handleDefaultLogin(decisionHandler: decisionHandler)
-                                            return
-                                        }
+                webView.evaluateJavaScript("document.querySelector('input[name=j_username]').value;") { (result, _) in
+                    if let pennkey = result as? String {
+                        webView.evaluateJavaScript("document.querySelector('input[name=j_password]').value;") { (result, _) in
+                            if let password = result as? String {
+                                if !pennkey.isEmpty && !password.isEmpty {
+                                    self.pennkey = pennkey
+                                    self.password = password
+                                    if pennkey == "root" && password == "root" {
+                                        self.handleDefaultLogin(decisionHandler: decisionHandler)
+                                        return
                                     }
                                 }
-                                decisionHandler(.allow)
                             }
-                        } else {
                             decisionHandler(.allow)
                         }
+                    } else {
+                        decisionHandler(.allow)
                     }
-                } else {
-                    decisionHandler(.allow)
                 }
             }
         }
@@ -123,7 +119,7 @@ class PennLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate 
             return
         }
 
-        if url.absoluteString.contains("twostep") {
+        if url.absoluteString.contains("prompt") {
             guard let pennkey = pennkey, let password = password else { return }
             if password != KeychainAccessible.instance.getPassword() {
                 UserDBManager.shared.updateAnonymizationKeys()
@@ -138,7 +134,7 @@ class PennLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate 
 
     func autofillCredentials() {
         guard let pennkey = pennkey else { return }
-        webView.evaluateJavaScript("document.getElementById('pennname').value = '\(pennkey)'") { (_, _) in
+        webView.evaluateJavaScript("document.getElementById('username').value = '\(pennkey)'") { (_, _) in
         }
         guard let password = password else { return }
         webView.evaluateJavaScript("document.getElementById('password').value = '\(password)'") { (_, _) in

--- a/PennMobile/Course Alerts/Networking/CourseAlertNetworkManager.swift
+++ b/PennMobile/Course Alerts/Networking/CourseAlertNetworkManager.swift
@@ -25,6 +25,7 @@ class CourseAlertNetworkManager: NSObject, Requestable {
     let settingsURL = "https://penncoursealert.com/accounts/me/"
     let coursesURL = "https://penncoursealert.com/api/base/"
     let registrationsURL = "https://penncoursealert.com/api/alert/registrations/"
+    let pathRegistrationURL = "https://penncourseplan.com/api/plan/schedules/path/"
 
     func getSearchedCourses(searchText: String, _ callback: @escaping (_ results: [CourseSection]?) -> Void) {
 
@@ -144,6 +145,29 @@ class CourseAlertNetworkManager: NSObject, Requestable {
         }
 
         makeAuthenticatedRequest(url: "\(registrationsURL)\(id)/", requestType: RequestType.PUT, params: params) { (data, status, error) in
+            guard let status = status as? HTTPURLResponse else {
+                callback(false, error)
+                return
+            }
+
+            guard data != nil else {
+                callback(false, error)
+                return
+            }
+
+            callback(status.statusCode == 200, error)
+        }
+    }
+
+    func updatePathRegistration(srcdb: String, crns: [String], callback: @escaping (_ success: Bool, _ error: Error?) -> Void) {
+        struct Section: Encodable {
+            var id: String // crn
+        }
+
+        let sections = crns.map { Section(id: $0) } 
+        let params: [String: Any] = ["semester": srcdb, "sections": sections]
+
+        makeAuthenticatedRequest(url: pathRegistrationURL, requestType: RequestType.PUT, params: params) { (data, status, error) in
             guard let status = status as? HTTPURLResponse else {
                 callback(false, error)
                 return

--- a/PennMobile/Courses/Views/CoursesView.swift
+++ b/PennMobile/Courses/Views/CoursesView.swift
@@ -51,7 +51,7 @@ struct CoursesView: View {
                 .foregroundColor(.red)
                 .padding()
                 .onAppear {
-                    if case PathAtPennError.noTokenFound = error {
+                    if case PathAtPennError.noTokenFound(_) = error {
                         isPresentingLoginSheet = true
                     }
                 }

--- a/PennMobile/Dining/Controllers/DiningLoginController.swift
+++ b/PennMobile/Dining/Controllers/DiningLoginController.swift
@@ -117,7 +117,7 @@ class DiningLoginController: UIViewController, WKUIDelegate, WKNavigationDelegat
 
         if url.absoluteString.contains("https://weblogin.pennkey.upenn.edu/") {
             guard let pennkey = KeychainAccessible.instance.getPennKey(), let password = KeychainAccessible.instance.getPassword() else { return }
-            webView.evaluateJavaScript("document.getElementById('pennname').value = '\(pennkey)'") { (_, _) in
+            webView.evaluateJavaScript("document.getElementById('username').value = '\(pennkey)'") { (_, _) in
                 webView.evaluateJavaScript("document.getElementById('password').value = '\(password)'") { (_, _) in
                 }
             }

--- a/PennMobile/Login/LabsLoginController.swift
+++ b/PennMobile/Login/LabsLoginController.swift
@@ -63,7 +63,7 @@ class LabsLoginController: PennLoginController, IndicatorEnabled, Requestable, S
     }
 
     override var shouldLoadCookies: Bool {
-        return false
+        return true
     }
 
     private let codeVerifier = String.randomString(length: 64)

--- a/PennMobile/Login/PathAtPennNetworkManager.swift
+++ b/PennMobile/Login/PathAtPennNetworkManager.swift
@@ -149,6 +149,20 @@ extension PathAtPennNetworkManager {
                 $0.split(separator: "|").first
             }
 
+            // Side effect: update Penn Course Plan Path Registration
+            try await withCheckedThrowingContinuation { continuation in
+                CourseAlertNetworkManager.instance.updatePathRegistration(srcdb: srcdb, crns: crns) { success, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if success {
+                        continuation.resume(returning: ())
+                    } else {
+                        // Handle the case where success is false and there's no error
+                        continuation.resume(throwing: NSError(domain: "UpdatePathRegistrationError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Unknown error occurred"]))
+                    }
+                }
+            }
+
             return try await crns.asyncMap { crn in
                 try await self.fetchCourse(srcdb: srcdb, crn: String(crn))
             }.compactMap { $0 }

--- a/PennMobile/Login/PathAtPennNetworkManager.swift
+++ b/PennMobile/Login/PathAtPennNetworkManager.swift
@@ -232,16 +232,6 @@ extension PathAtPennNetworkManager {
                 $0.split(separator: "|").first.map { String($0) }
             }
 
-            // Side effect: update Penn Course Plan Path Registration
-            // TODO: Add a guard here to ensure privacy
-            Task {
-                do {
-                    try await CourseAlertNetworkManager.instance.updatePathRegistration(srcdb: srcdb, crns: crns)
-                } catch {
-                    self.logger.error("Couldn't update PCP registration: \(error)")
-                }
-            }
-
             return try await crns.asyncMap { crn in
                 try await self.fetchCourse(srcdb: srcdb, crn: crn)
             }.compactMap { $0 }

--- a/PennMobileShared/General/Extensions.swift
+++ b/PennMobileShared/General/Extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import OSLog
 
 extension UIApplication {
     public static var isRunningFastlaneTest: Bool {
@@ -666,5 +667,11 @@ public extension JSONDecoder {
         self.init()
         self.keyDecodingStrategy = keyDecodingStrategy
         self.dateDecodingStrategy = dateDecodingStrategy
+    }
+}
+
+public extension Logger {
+    init(category: String) {
+        self.init(subsystem: Bundle.main.bundleIdentifier ?? "Penn Mobile", category: category)
     }
 }

--- a/Widget/Dining Hours/DiningHoursWidget.swift
+++ b/Widget/Dining Hours/DiningHoursWidget.swift
@@ -120,6 +120,8 @@ struct DiningHoursWidget: Widget {
         .contentMarginsDisabled()
     }
 }
+
+@available(iOS 17.0, *)
 #Preview(as: .systemSmall) {
     DiningHoursWidget()
 } timeline: {


### PR DESCRIPTION
This PR adds an `updatePathRegistration` method to the existing `CourseAlertNetworkManager`, which maybe we should rename to something more generic to the Penn Courses backend (not important). This method can be used to upsert the user's Path registration as a PCP schedule. This method will be called as a side effect by `fetchStudentCourses`.

This PR also modifies the `getToken` method in `PathAtPennNetworkManager`. I don't think this method actually works currently. It pulls the user's pennkey and password from `KeychainAccessible`, and their Duo cookies from `PennLoginController`’s `WKWebsiteDataStore`. If the username/password are stored and the duo cookie isn't expired (check for cookie expiration before sending request so we don't trigger errant 2FA push notification), it initiates the Penn auth flow by sending a POST request to `https://weblogin.pennkey.upenn.edu/idp/profile/oidc/authorize?execution=e1s1&eventTag=password` with the following `application/x-www-form-urlencoded` content:
```
j_username=pennkey&j_password=password&_eventId_proceed=
```
(where `pennkey` is the user's pennkey and `password` is the user's password, both URLencoded)

This flow will eventually redirect to Duo, which uses a cookie with a key like `fsc|DU8WC5BNIIZ03YFXMNNK` to bypass 2FA (this cookie is set when the user clicks "remember this device" in the 2FA flow upon app login). If the auth flow fails for any reason, `getToken` raises and log the user out, so that the next time they login they will refresh their pennkey credentials and Duo cookie.

Finally, the auth flow returns the token in the same format currently assumed by the `getToken` function (so the parsing can stay the same).

Besides modifying `getToken` to actually work, this PR handles accepting a silent push notification from mobile backend(?) to trigger refreshing of a student's courses (say once per hour).

If we really think a user's Path course schedule is sensitive info (it's not imo), we should also add an opt-in popup so that the user's schedule isn't synced with PCP until/unless they grant permission. But imo since the data isn't rly sensitive enough to warrant off-server storage and won't be leaving the Penn Labs ecosystem anyway (which already stores sensitive info and is very careful about user privacy), this seems like unnecessary dev time and user burden for what it accomplishes. Def up for discussion.