### PR TITLE
Change feedback URL

### DIFF
--- a/PennMobile/More Tab/MoreViewController.swift
+++ b/PennMobile/More Tab/MoreViewController.swift
@@ -80,7 +80,7 @@ class MoreViewController: GenericTableViewController, ShowsAlert {
         PennLink(title: "Canvas", url: "https://canvas.upenn.edu"),
         PennLink(title: "Path@Penn", url: "https://path.at.upenn.edu"),
         PennLink(title: "PennPortal", url: "https://portal.apps.upenn.edu/penn_portal"),
-        PennLink(title: "Share Your Feedback", url: "https://airtable.com/shrS98E3rj5Nw1wy6")]
+        PennLink(title: "Share Your Feedback", url: "https://pennlabs.org/feedback/ios")]
 
 }
 


### PR DESCRIPTION
Since the feedback form was changed, this PR updates the "Share Your Feedback" URL to be in line with pennlabs/website#231.
