### PR TITLE
Make project compile under Xcode 15.1

### DIFF
--- a/Widget/Dining Hours/DiningHoursWidget.swift
+++ b/Widget/Dining Hours/DiningHoursWidget.swift
@@ -120,6 +120,8 @@ struct DiningHoursWidget: Widget {
         .contentMarginsDisabled()
     }
 }
+
+@available(iOS 17.0, *)
 #Preview(as: .systemSmall) {
     DiningHoursWidget()
 } timeline: {


### PR DESCRIPTION
For some reason Xcode 15.1 began complaining about this. I've made this change already in #495 and #497, but figured I'd add it here so we can quickly get it merged in.
