### PR TITLE
Add explanatory message for Dining Analytics not appearing before semester begins

### DIFF
--- a/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
+++ b/PennMobile/Dining/SwiftUI/DiningAnalyticsView.swift
@@ -36,11 +36,16 @@ struct DiningAnalyticsView: View {
                             Image("DiningAnalyticsBackground")
                                 .resizable()
                                 .ignoresSafeArea()
-                            Text("No Dining\nPlan Found\n ")
-                                .multilineTextAlignment(.center)
-                                .font(.system(size: 48, weight: .regular))
-                                .foregroundColor(.black)
-                                .opacity(0.6)
+                            VStack(spacing: 24) {
+                                Text("No Dining Plan Found")
+                                    .font(.system(size: 48, weight: .regular))
+                                Text("Dining Analytics may not appear until the day after the semester begins.")
+                            }
+                            .frame(maxWidth: 280)
+                            .padding(.bottom, 64)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.black)
+                            .opacity(0.6)
                         }
                     } else {
                         ScrollView {


### PR DESCRIPTION
Amends the "No Dining Plan" screen with the following text:

> Dining Analytics may not appear until the day after the semester begins.
