### PR TITLE
fix: indicate venue is closed when it has no hours in detailed hours views

### DIFF
--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailHoursView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailHoursView.swift
@@ -28,6 +28,14 @@ struct DiningVenueDetailHoursView: View {
                     .font(duration == Date().integerDayOfWeek ? .system(size: 18, weight: .bold): .system(size: 18, weight: .regular))
 
                 HStack {
+                    if venue.formattedHoursArrayFor(date).isEmpty {
+                        Text("Closed")
+                            .padding(.vertical, 3)
+                            .padding(.horizontal, 4)
+                            .font(.system(size: 14, weight: .light, design: .default))
+                            .background(Color.grey5)
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
                     ForEach(venue.formattedHoursArrayFor(date), id: \.self) { hours in
                         Text(hours)
                             .padding(.vertical, 3)


### PR DESCRIPTION
Currently, when a venue is closed, it displays nothing under the week day. This PR makes it say "closed" instead.

Before:
<img src="https://github.com/pennlabs/penn-mobile-ios/assets/78520093/e272c2aa-6d32-4964-95c2-f5c8c257cebb" width="300">

After:
<img src="https://github.com/pennlabs/penn-mobile-ios/assets/78520093/484a35ed-b6d5-472a-8fa6-7c6e132cb2da" width="300">
