### PR TITLE
Tweak home page styling

### DIFF
--- a/PennMobile/Home/HomeCardView.swift
+++ b/PennMobile/Home/HomeCardView.swift
@@ -76,14 +76,17 @@ struct GenericPostCardView: View {
                         .scaledToFill()
                     
                     content
-                        .background(.regularMaterial)
                         .background(alignment: .top) {
-                            KFImage(imageURL)
-                                .resizable()
-                                .scaledToFill()
-                                .scaleEffect(x: 1, y: -1)
-                                .clipped()
+                            ZStack {
+                                KFImage(imageURL)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .scaleEffect(x: 1, y: -1)
+                                Rectangle().fill(.regularMaterial)
+                            }
+                            .drawingGroup()
                         }
+                        .clipped()
                 }
             } else {
                 content

--- a/PennMobile/Home/HomeCardView.swift
+++ b/PennMobile/Home/HomeCardView.swift
@@ -61,7 +61,6 @@ struct GenericPostCardView: View {
             if let description {
                 Text(description)
                     .font(.caption)
-                    .lineLimit(3)
             }
         }
         .padding()
@@ -71,30 +70,21 @@ struct GenericPostCardView: View {
     var body: some View {
         HomeCardView {
             if let imageURL {
-                ZStack(alignment: .bottom) {
-                    Rectangle().fill(Material.ultraThin)
-                        .background(
-                            KFImage(imageURL)
-                                .resizable()
-                                .scaledToFill()
-                        )
+                VStack(spacing: 0) {
+                    KFImage(imageURL)
+                        .resizable()
+                        .scaledToFill()
                     
-                    Rectangle().fill(.clear)
-                        .overlay(
+                    content
+                        .background(.regularMaterial)
+                        .background(alignment: .top) {
                             KFImage(imageURL)
                                 .resizable()
                                 .scaledToFill()
-                        )
-                        .mask(alignment: .top) {
-                            VStack(spacing: 0) {
-                                Rectangle().fill(.white).frame(height: 93)
-                                LinearGradient(colors: [.white, .clear], startPoint: .top, endPoint: .bottom).frame(height: 64)
-                            }
+                                .scaleEffect(x: 1, y: -1)
+                                .clipped()
                         }
-                    
-                    content.padding(.top, 150)
                 }
-                .environment(\.colorScheme, .dark)
             } else {
                 content
             }
@@ -181,5 +171,7 @@ struct NewsDetailView: UIViewControllerRepresentable {
         PostCardView(post: Post(id: 1, title: "Congratulations!", subtitle: "You are our lucky winner", postUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", imageUrl: "https://www.cnet.com/a/img/resize/2bec42558a71a3922e6e590476b919288a015288/hub/2017/06/01/a176bcb9-1442-4d6d-a7d9-f01efdbcc4bc/broken-screen-ipad-6200-002.jpg?auto=webp&fit=crop&height=675&width=1200", createdDate: Date(), startDate: Date.midnightYesterday, expireDate: Date.midnightToday, source: "Totally Legit Source"))
     }
     .frame(width: 400)
+    .fixedSize(horizontal: false, vertical: true)
     .padding(.vertical)
+    .frame(maxHeight: .infinity)
 }

--- a/PennMobile/Home/HomeView.swift
+++ b/PennMobile/Home/HomeView.swift
@@ -22,14 +22,6 @@ struct HomeView<Model: HomeViewModel>: View {
             .day()
     }
     
-    var backgroundGradient: some View {
-        if colorScheme == .dark {
-            return LinearGradient(colors: [Color("baseDarkBlue"), .clear], startPoint: .topLeading, endPoint: .center)
-        } else {
-            return LinearGradient(colors: [Color("baseLabsBlue").opacity(0.15), .clear], startPoint: .topLeading, endPoint: .center)
-        }
-    }
-    
     var body: some View {
         Group {
             switch viewModel.data {
@@ -37,7 +29,6 @@ struct HomeView<Model: HomeViewModel>: View {
                 ProgressView()
                     .controlSize(.large)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(backgroundGradient)
                     .ignoresSafeArea()
             case .some(.success(let data)):
                 NavigationStack {
@@ -97,7 +88,6 @@ struct HomeView<Model: HomeViewModel>: View {
                     .refreshable {
                         try? await viewModel.fetchData(force: true)
                     }
-                    .background(backgroundGradient.ignoresSafeArea(edges: .all))
                 }
             case .some(.failure(let error)):
                 VStack(spacing: 16) {
@@ -126,8 +116,6 @@ struct HomeView<Model: HomeViewModel>: View {
                 .multilineTextAlignment(.center)
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(LinearGradient(colors: [.red, .clear], startPoint: .topLeading, endPoint: .center))
-                .ignoresSafeArea()
             }
         }.onAppear {
             Task {

--- a/PennMobile/Home/HomeView.swift
+++ b/PennMobile/Home/HomeView.swift
@@ -23,7 +23,11 @@ struct HomeView<Model: HomeViewModel>: View {
     }
     
     var backgroundGradient: some View {
-        LinearGradient(colors: [colorScheme == .dark ? Color("baseDarkBlue") : Color("baseLabsBlue").opacity(0.5), .clear], startPoint: .topLeading, endPoint: .center)
+        if colorScheme == .dark {
+            return LinearGradient(colors: [Color("baseDarkBlue"), .clear], startPoint: .topLeading, endPoint: .center)
+        } else {
+            return LinearGradient(colors: [Color("baseLabsBlue").opacity(0.15), .clear], startPoint: .topLeading, endPoint: .center)
+        }
     }
     
     var body: some View {
@@ -47,7 +51,7 @@ struct HomeView<Model: HomeViewModel>: View {
                                         .background(GeometryReader { geometry in
                                             let minY = geometry.frame(in: .global).minY
                                             Color.clear.onChange(of: minY) { minY in
-                                                showTitle = minY <= 32
+                                                showTitle = minY <= 16
                                             }
                                         })
                                     
@@ -55,8 +59,8 @@ struct HomeView<Model: HomeViewModel>: View {
                                         HStack(alignment: .top) {
                                             Text(splashText)
                                                 .fontWeight(.medium)
+                                                .opacity(0.7)
                                         }
-                                        .foregroundStyle(.secondary)
                                     }
                                 }
                                 .offset(y: -16)


### PR DESCRIPTION
Implements a few changes to the home page design to make it line up more nicely with the existing home page, as per discussion with @joycecheen and @ccxcheng:

* Nukes the (admittedly polarizing) background gradient
* Tweaks the styling of the splash text ("Howdy, Anthony!")
* Removes the gradient and displays full images on cards with image backgrounds

![Screenshot of tweaked home page](https://github.com/pennlabs/penn-mobile-ios/assets/7005789/beb03d06-335e-4876-b056-08313d0e4563)