### PR TITLE
Fix navigation warning (the yellow warning screen) when sending interest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,7 @@ GEM
 PLATFORMS
   universal-darwin-21
   universal-darwin-22
+  universal-darwin-23
   x86_64-darwin-19
   x86_64-linux
 

--- a/PennMobile/Subletting/SubletInterestForm.swift
+++ b/PennMobile/Subletting/SubletInterestForm.swift
@@ -53,7 +53,7 @@ struct SubletInterestForm: View {
                                     message: "The renter will reach out to you if interested.",
                                     button1: "See Applied",
                                     action1: {
-                                        navigationManager.path.removeAll()
+                                        navigationManager.path.removeLast(navigationManager.path.contains(SublettingPage.myActivity(.saved)) ? 3 : 2)
                                         navigationManager.path.append(SublettingPage.myActivity(.applied))
                                     },
                                     button2: "Keep Browsing",


### PR DESCRIPTION
I haven't been able to test this because I can't log into Penn Mobile on my simulator (a separate issue), so can someone else test this for me? Just indicate interest in a sublet, and then clicking the "See Applied" should take you to the applied screen instead of showing a warning. Test this both when subletting is on the more tab and when it's in the nav bar.