### PR TITLE
Fix crash from unwrapping optional in GSRController

### DIFF
--- a/PennMobile/GSR-Booking/Controllers/GSRController.swift
+++ b/PennMobile/GSR-Booking/Controllers/GSRController.swift
@@ -214,6 +214,7 @@ extension GSRController: GSRBookable {
 
             if times.count == 0 {
                 showAlert(withMsg: "Please select a timeslot to book.", title: "Empty Selection", completion: nil)
+                return
             }
 
             let sorted = times.sorted(by: {$0.startTime < $1.startTime})


### PR DESCRIPTION
We were getting a few crashes due to this.

<img width="752" alt="Crash log from unwrapping sorted.first!" src="https://github.com/pennlabs/penn-mobile-ios/assets/7005789/04cd5b4d-a9de-44bc-9000-07d8ecb01b03">