### PR TITLE
Fix Listing Name field weirdness

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -3329,8 +3329,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pennlabs/PennForms";
 			requirement = {
-				kind = revision;
-				revision = aff2ed4611e71bc5c7b16dfae9636789e06993b7;
+				branch = subletting;
+				kind = branch;
 			};
 		};
 		F213CCE023C3EE3E000AD90F /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/PennMobile/Subletting/Listings/NewListingForm.swift
+++ b/PennMobile/Subletting/Listings/NewListingForm.swift
@@ -67,7 +67,7 @@ struct NewListingForm: View {
     init(sublet: Sublet) {
         self.isNew = false
         self.originalSublet = sublet
-        self._subletData = State(initialValue: sublet.data)
+        self._subletData = State(initialValue: SubletData())
         self._negotiable = State(initialValue: sublet.negotiable)
         self._price = State(initialValue: sublet.price)
         self._startDate = State(initialValue: sublet.startDate.date)
@@ -76,7 +76,7 @@ struct NewListingForm: View {
         self._images = State(initialValue: [])
         self._existingImages = State(initialValue: sublet.images.map { $0.imageUrl })
         
-        self.showValidationErrors = true
+        self.showValidationErrors = false
     }
     
     var body: some View {
@@ -358,6 +358,18 @@ struct NewListingForm: View {
             }
         }
         .environment(\.showValidationErrors, showValidationErrors)
+        .onAppear {
+            // HACK: Listing Name field shows really weird behavior unless we do this??
+            if !isNew {
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(1)) {
+                    if let originalSublet {
+                        subletData = originalSublet.data
+                    }
+                    
+                    showValidationErrors = true
+                }
+            }
+        }
     }
 }
 

--- a/PennMobile/Subletting/SublettingViewModel.swift
+++ b/PennMobile/Subletting/SublettingViewModel.swift
@@ -22,7 +22,7 @@ struct MarketplaceFilterData: Codable {
     var selectedAmenities = OrderedSet<String>()
 }
 
-class SublettingViewModel: ObservableObject {
+@MainActor class SublettingViewModel: ObservableObject {
     @Published private var sublets: [Int: Sublet] = [:]
     var sortedFilteredSublets: [Sublet] {
         let filtered = filteredIDs.compactMap { sublets[$0] }
@@ -228,11 +228,8 @@ class SublettingViewModel: ObservableObject {
         return savedIDs.contains(sublet.subletID)
     }
     
-    private let subletUpdateQueue = DispatchQueue(label: "subletUpdateQueue")
     func updateSublet(sublet: Sublet) {
-        subletUpdateQueue.sync {
-            sublets[sublet.subletID] = sublet
-        }
+        sublets[sublet.subletID] = sublet
     }
     
     func getSublet(subletID: Int) -> Sublet? {


### PR DESCRIPTION
Applies the following changes:
* Ensures that sublet view model updates always occur on the main thread, which should eliminate sources of deadlock/race conditions/bugs in general
* Updates PennForms to the `subletting` branch (which is intended to become the de facto main branch for subletting purposes) in order to fix not being able to tap on the Listing Name field
* Applies a ~~hack~~ carefully studied approach to ensure that the Listing Name field always populates ~~sh ignore the asyncAfter we totally don't just give up and load everything 1 ms after the view appears~~
