### PR TITLE
Improve keyboard dismissing for subletting

### DIFF
--- a/PennMobile/General/SwiftUI Views/CustomPopupView.swift
+++ b/PennMobile/General/SwiftUI Views/CustomPopupView.swift
@@ -36,6 +36,11 @@ class PopupManager: ObservableObject {
     }
     
     public func show() {
+        if !isShown {
+            // https://www.hackingwithswift.com/quick-start/swiftui/how-to-dismiss-the-keyboard-for-a-textfield
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+        
         withAnimation {
             self.isShown = true
         }

--- a/PennMobile/Subletting/Listings/NewListingForm.swift
+++ b/PennMobile/Subletting/Listings/NewListingForm.swift
@@ -370,6 +370,7 @@ struct NewListingForm: View {
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
     }
 }
 

--- a/PennMobile/Subletting/MarketplaceFilterView.swift
+++ b/PennMobile/Subletting/MarketplaceFilterView.swift
@@ -88,6 +88,7 @@ struct MarketplaceFilterView: View {
                     }
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
             .navigationBarTitle(Text("Filter by"), displayMode: .inline)
             .navigationBarItems(leading: Button(action: {
                 dismiss()

--- a/PennMobile/Subletting/SubletInterestForm.swift
+++ b/PennMobile/Subletting/SubletInterestForm.swift
@@ -96,6 +96,7 @@ struct SubletInterestForm: View {
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .navigationTitle("Send Interest")
     }
 }


### PR DESCRIPTION
* Allows users to interactively swipe away the keyboard on subletting forms
* Force hides the keyboard when a `PopupManager` popup displays (yes this is hacky i know)
