### PR TITLE
Prevent activityIndicatorBackground force unwrapping crash

### DIFF
--- a/PennMobile/Auth/PennLoginController.swift
+++ b/PennMobile/Auth/PennLoginController.swift
@@ -75,8 +75,10 @@ class PennLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate 
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        activityIndicatorBackground.center = view.center
-        view.bringSubviewToFront(activityIndicatorBackground)
+        if let activityIndicatorBackground {
+            activityIndicatorBackground.center = view.center
+            view.bringSubviewToFront(activityIndicatorBackground)
+        }
     }
 
     func webView(


### PR DESCRIPTION
Prevents a crash in case `viewDidLayoutSubviews()` is called before `configureAndLoad()`.
