### PR TITLE
feat: dismiss sublet marketplace search keyboard immediately when scrolling

### DIFF
--- a/PennMobile/Subletting/MarketplaceView.swift
+++ b/PennMobile/Subletting/MarketplaceView.swift
@@ -203,7 +203,7 @@ struct MarketplaceView: View {
                 await sublettingViewModel.populateSublets()
                 await sublettingViewModel.populateFiltered()
             }
-            .scrollDismissesKeyboard(.immediately)
+            .scrollDismissesKeyboard(.interactively)
         }
         .toolbar {
             ToolbarItem {

--- a/PennMobile/Subletting/MarketplaceView.swift
+++ b/PennMobile/Subletting/MarketplaceView.swift
@@ -203,6 +203,7 @@ struct MarketplaceView: View {
                 await sublettingViewModel.populateSublets()
                 await sublettingViewModel.populateFiltered()
             }
+            .scrollDismissesKeyboard(.immediately)
         }
         .toolbar {
             ToolbarItem {


### PR DESCRIPTION
This PR dismisses the keyboard, which appears when you search for a sublet, immediately upon scrolling.

https://github.com/user-attachments/assets/56397a1f-2366-44f5-90f1-346580728cec

