### PR TITLE
feat: add circle indicators for swiping images

### DIFF
--- a/PennMobile/Subletting/SubletDetailView.swift
+++ b/PennMobile/Subletting/SubletDetailView.swift
@@ -98,6 +98,7 @@ struct SubletDetailView: View {
 struct SubletDetailOnly: View {
     private var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
     @EnvironmentObject var sublettingViewModel: SublettingViewModel
+    @State private var currentIndex = 0
     var sublet: Sublet
     var isSaved: Bool {
         sublettingViewModel.isFavorited(sublet: sublet)
@@ -113,19 +114,31 @@ struct SubletDetailOnly: View {
         
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            TabView {
-                ForEach(sublet.images) { image in
-                    KFImage(URL(string: image.imageUrl))
+            TabView(selection: $currentIndex) {
+                ForEach(sublet.images.indices, id: \.self) { index in
+                    KFImage(URL(string: sublet.images[index].imageUrl))
                         .placeholder {
                             ProgressView()
                         }
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .cornerRadius(10)
+                        .tag(index)
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .frame(height: 300)
+            
+            if sublet.images.count > 1 {
+                HStack(spacing: 8) {
+                    ForEach(0..<sublet.images.count, id: \.self) { index in
+                        Circle()
+                            .fill(currentIndex == index ? Color.baseLabsBlue : .secondary)
+                            .frame(width: 6, height: 6)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
             
             VStack(alignment: .leading) {
                 HStack {


### PR DESCRIPTION
This PR introduces indicators for when images in a sublet detail view are swipeable. 

Max Images (6):
<img src="https://github.com/user-attachments/assets/413befc5-9765-4918-8899-df98321aa787" width="300px">

Swiping:
<img src="https://github.com/user-attachments/assets/83df7cad-a4e0-4cca-b027-1e5e3ba3a927" width="300px">

<= 1 Images:
<img src="https://github.com/user-attachments/assets/fde59702-0ad9-4a8c-8708-e89731efc638" width="300px">

