### PR TITLE
Add more options for candidate contact info

### DIFF
--- a/PennMobile/Subletting/SubletCandidatesView.swift
+++ b/PennMobile/Subletting/SubletCandidatesView.swift
@@ -14,21 +14,49 @@ struct CandidateRow: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Button(action: {
-                guard let url = URL(string: "mailto:\(offer.email)") else { return }
-                UIApplication.shared.open(url)
-            }) {
+            Menu {
+                Button(action: {
+                    guard let url = URL(string: "mailto:\(offer.email)") else { return }
+                    UIApplication.shared.open(url)
+                }) {
+                    Label("Send Email", systemImage: "envelope")
+                }
+                
+                Button(action: {
+                    UIPasteboard.general.string = offer.email
+                }) {
+                    Label("Copy Email", systemImage: "doc.on.doc")
+                }
+            } label: {
                 Text(offer.email)
                     .font(.headline)
             }
             
             HStack {
                 Image(systemName: "phone")
-                Button(action: {
-                    guard let url = URL(string: "tel:\(offer.phoneNumber)") else { return }
-                    UIApplication.shared.open(url)
-                }) {
+                Menu {
+                    Button(action: {
+                        guard let url = URL(string: "tel:\(offer.phoneNumber)") else { return }
+                        UIApplication.shared.open(url)
+                    }) {
+                        Label("Call Number", systemImage: "phone")
+                    }
+                    
+                    Button(action: {
+                        guard let url = URL(string: "sms:\(offer.phoneNumber)") else { return }
+                        UIApplication.shared.open(url)
+                    }) {
+                        Label("Send Message", systemImage: "message")
+                    }
+                    
+                    Button(action: {
+                        UIPasteboard.general.string = offer.phoneNumber
+                    }) {
+                        Label("Copy Number", systemImage: "doc.on.doc")
+                    }
+                } label: {
                     Text(offer.phoneNumber)
+                        .font(.headline)
                 }
             }
             .font(.subheadline)

--- a/PennMobile/Subletting/SubletCandidatesView.swift
+++ b/PennMobile/Subletting/SubletCandidatesView.swift
@@ -14,22 +14,26 @@ struct CandidateRow: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Menu {
-                Button(action: {
-                    guard let url = URL(string: "mailto:\(offer.email)") else { return }
-                    UIApplication.shared.open(url)
-                }) {
-                    Label("Send Email", systemImage: "envelope")
-                }
+            HStack {
+                Image(systemName: "envelope")
                 
-                Button(action: {
-                    UIPasteboard.general.string = offer.email
-                }) {
-                    Label("Copy Email", systemImage: "doc.on.doc")
+                Menu {
+                    Button(action: {
+                        guard let url = URL(string: "mailto:\(offer.email)") else { return }
+                        UIApplication.shared.open(url)
+                    }) {
+                        Label("Send Email", systemImage: "envelope")
+                    }
+                    
+                    Button(action: {
+                        UIPasteboard.general.string = offer.email
+                    }) {
+                        Label("Copy Email", systemImage: "doc.on.doc")
+                    }
+                } label: {
+                    Text(offer.email)
+                        .font(.headline)
                 }
-            } label: {
-                Text(offer.email)
-                    .font(.headline)
             }
             
             HStack {
@@ -52,7 +56,7 @@ struct CandidateRow: View {
                     Button(action: {
                         UIPasteboard.general.string = offer.phoneNumber
                     }) {
-                        Label("Copy Number", systemImage: "doc.on.doc")
+                        Label("Copy", systemImage: "doc.on.doc")
                     }
                 } label: {
                     Text(offer.phoneNumber)


### PR DESCRIPTION
This PR adds a copy option to the email button in the sublet candidates view as well as a text and copy button to the phone number button. It also adds an email icon to the left of the email.

# Before: 
<img src="https://github.com/user-attachments/assets/36d158e6-b5bd-40f9-b7c9-a583098cb414" alt="Before" width="300"/>

# After:
<img src="https://github.com/user-attachments/assets/21925009-fb9b-464f-892d-db441af04aae" alt="After 1" width="300"/>
<img src="https://github.com/user-attachments/assets/4426f8c5-c9d1-4c88-a2c4-edb5819b54e4" alt="After 2" width="300"/>
<img src="https://github.com/user-attachments/assets/90caf81e-c0f2-42dd-a5f9-008a4412144b" alt="After 3" width="300"/>
