### PR TITLE
Convert folder references back to groups

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -28,6 +28,364 @@
 		8932693728FC75A5003D4BF9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693628FC75A5003D4BF9 /* SwiftUI.framework */; };
 		8932694428FC75A6003D4BF9 /* WidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 8932693328FC75A5003D4BF9 /* WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8932694D28FC79FB003D4BF9 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 8932694C28FC79FB003D4BF9 /* SwiftyJSON */; };
+		8969F2D92CB98B860063FFD1 /* PennMobileShared.h in Headers */ = {isa = PBXBuildFile; fileRef = 8969F2D72CB98B860063FFD1 /* PennMobileShared.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8969F2DA2CB98B860063FFD1 /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2AF2CB98B860063FFD1 /* Course.swift */; };
+		8969F2DB2CB98B860063FFD1 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B02CB98B860063FFD1 /* ScheduleView.swift */; };
+		8969F2DC2CB98B860063FFD1 /* DiningBalance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B22CB98B860063FFD1 /* DiningBalance.swift */; };
+		8969F2DD2CB98B860063FFD1 /* DiningMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B32CB98B860063FFD1 /* DiningMenu.swift */; };
+		8969F2DE2CB98B860063FFD1 /* DiningPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B42CB98B860063FFD1 /* DiningPlan.swift */; };
+		8969F2DF2CB98B860063FFD1 /* DiningToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B52CB98B860063FFD1 /* DiningToken.swift */; };
+		8969F2E02CB98B860063FFD1 /* DiningVenue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B62CB98B860063FFD1 /* DiningVenue.swift */; };
+		8969F2E12CB98B860063FFD1 /* DiningVenue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B72CB98B860063FFD1 /* DiningVenue+Extensions.swift */; };
+		8969F2E22CB98B860063FFD1 /* PastDiningBalances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2B82CB98B860063FFD1 /* PastDiningBalances.swift */; };
+		8969F2E32CB98B860063FFD1 /* DiningAnalyticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2BA2CB98B860063FFD1 /* DiningAnalyticsViewModel.swift */; };
+		8969F2E42CB98B860063FFD1 /* DiningAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2BB2CB98B860063FFD1 /* DiningAPI.swift */; };
+		8969F2E52CB98B860063FFD1 /* DiningVenueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2BC2CB98B860063FFD1 /* DiningVenueRow.swift */; };
+		8969F2E62CB98B860063FFD1 /* FitnessAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2BE2CB98B860063FFD1 /* FitnessAPI.swift */; };
+		8969F2E72CB98B860063FFD1 /* FitnessGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2BF2CB98B860063FFD1 /* FitnessGraph.swift */; };
+		8969F2E82CB98B860063FFD1 /* FitnessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C02CB98B860063FFD1 /* FitnessModel.swift */; };
+		8969F2E92CB98B860063FFD1 /* BadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C22CB98B860063FFD1 /* BadgeView.swift */; };
+		8969F2EA2CB98B860063FFD1 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C32CB98B860063FFD1 /* Colors.swift */; };
+		8969F2EB2CB98B860063FFD1 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C42CB98B860063FFD1 /* Day.swift */; };
+		8969F2EC2CB98B860063FFD1 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C52CB98B860063FFD1 /* Extensions.swift */; };
+		8969F2ED2CB98B860063FFD1 /* KeychainAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C62CB98B860063FFD1 /* KeychainAccessible.swift */; };
+		8969F2EE2CB98B860063FFD1 /* MeterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C72CB98B860063FFD1 /* MeterView.swift */; };
+		8969F2EF2CB98B860063FFD1 /* PhoneNumberFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C82CB98B860063FFD1 /* PhoneNumberFormat.swift */; };
+		8969F2F02CB98B860063FFD1 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2C92CB98B860063FFD1 /* SearchBar.swift */; };
+		8969F2F12CB98B860063FFD1 /* SecureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2CA2CB98B860063FFD1 /* SecureStore.swift */; };
+		8969F2F22CB98B860063FFD1 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2CB2CB98B860063FFD1 /* Storage.swift */; };
+		8969F2F32CB98B860063FFD1 /* WidgetKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2CC2CB98B860063FFD1 /* WidgetKind.swift */; };
+		8969F2F42CB98B860063FFD1 /* LaundryAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2CE2CB98B860063FFD1 /* LaundryAttributes.swift */; };
+		8969F2F52CB98B860063FFD1 /* LaundryMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2CF2CB98B860063FFD1 /* LaundryMachine.swift */; };
+		8969F2F62CB98B860063FFD1 /* Multipart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2D12CB98B860063FFD1 /* Multipart.swift */; };
+		8969F2F72CB98B860063FFD1 /* NetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2D22CB98B860063FFD1 /* NetworkingError.swift */; };
+		8969F2F82CB98B860063FFD1 /* SubletDisplayBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2D42CB98B860063FFD1 /* SubletDisplayBox.swift */; };
+		8969F2F92CB98B860063FFD1 /* SublettingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2D52CB98B860063FFD1 /* SublettingModels.swift */; };
+		8969F4902CB98B890063FFD1 /* OAuth2NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2FA2CB98B890063FFD1 /* OAuth2NetworkManager.swift */; };
+		8969F4912CB98B890063FFD1 /* PennAuthRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2FB2CB98B890063FFD1 /* PennAuthRequestable.swift */; };
+		8969F4922CB98B890063FFD1 /* PennLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2FC2CB98B890063FFD1 /* PennLoginController.swift */; };
+		8969F4932CB98B890063FFD1 /* BannerDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2FE2CB98B890063FFD1 /* BannerDescription.swift */; };
+		8969F4942CB98B890063FFD1 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F2FF2CB98B890063FFD1 /* BannerView.swift */; };
+		8969F4952CB98B890063FFD1 /* BannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3002CB98B890063FFD1 /* BannerViewModel.swift */; };
+		8969F4962CB98B890063FFD1 /* UserEngagementPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3012CB98B890063FFD1 /* UserEngagementPopupView.swift */; };
+		8969F4972CB98B890063FFD1 /* BuildingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3032CB98B890063FFD1 /* BuildingCell.swift */; };
+		8969F4982CB98B890063FFD1 /* BuildingFoodMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3042CB98B890063FFD1 /* BuildingFoodMenuCell.swift */; };
+		8969F4992CB98B890063FFD1 /* BuildingHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3052CB98B890063FFD1 /* BuildingHeaderCell.swift */; };
+		8969F49A2CB98B890063FFD1 /* BuildingHoursCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3062CB98B890063FFD1 /* BuildingHoursCell.swift */; };
+		8969F49B2CB98B890063FFD1 /* BuildingImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3072CB98B890063FFD1 /* BuildingImageCell.swift */; };
+		8969F49C2CB98B890063FFD1 /* BuildingMapCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3082CB98B890063FFD1 /* BuildingMapCell.swift */; };
+		8969F49D2CB98B890063FFD1 /* BuildingSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3092CB98B890063FFD1 /* BuildingSectionHeader.swift */; };
+		8969F49E2CB98B890063FFD1 /* MenuTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F30A2CB98B890063FFD1 /* MenuTableView.swift */; };
+		8969F49F2CB98B890063FFD1 /* BuildingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F30C2CB98B890063FFD1 /* BuildingProtocol.swift */; };
+		8969F4A02CB98B890063FFD1 /* ScannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3122CB98B890063FFD1 /* ScannerState.swift */; };
+		8969F4A12CB98B890063FFD1 /* ScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3142CB98B890063FFD1 /* ScannerView.swift */; };
+		8969F4A22CB98B890063FFD1 /* ScannerViewfinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3152CB98B890063FFD1 /* ScannerViewfinder.swift */; };
+		8969F4A32CB98B890063FFD1 /* ScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3162CB98B890063FFD1 /* ScannerViewModel.swift */; };
+		8969F4A42CB98B890063FFD1 /* TicketingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3182CB98B890063FFD1 /* TicketingAPI.swift */; };
+		8969F4A52CB98B890063FFD1 /* ContactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F31A2CB98B890063FFD1 /* ContactCell.swift */; };
+		8969F4A62CB98B890063FFD1 /* ContactManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F31B2CB98B890063FFD1 /* ContactManager.swift */; };
+		8969F4A72CB98B890063FFD1 /* ContactsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F31C2CB98B890063FFD1 /* ContactsTableViewController.swift */; };
+		8969F4A82CB98B890063FFD1 /* SupportItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 8969F31E2CB98B890063FFD1 /* SupportItem.m */; };
+		8969F4A92CB98B890063FFD1 /* CourseAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3202CB98B890063FFD1 /* CourseAlertController.swift */; };
+		8969F4AA2CB98B890063FFD1 /* CourseAlertCreateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3212CB98B890063FFD1 /* CourseAlertCreateController.swift */; };
+		8969F4AB2CB98B890063FFD1 /* CourseAlertSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3222CB98B890063FFD1 /* CourseAlertSettingsController.swift */; };
+		8969F4AC2CB98B890063FFD1 /* CourseAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3242CB98B890063FFD1 /* CourseAlert.swift */; };
+		8969F4AD2CB98B890063FFD1 /* CourseAlertSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3252CB98B890063FFD1 /* CourseAlertSettings.swift */; };
+		8969F4AE2CB98B890063FFD1 /* CourseAlertSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3262CB98B890063FFD1 /* CourseAlertSettingsOptions.swift */; };
+		8969F4AF2CB98B890063FFD1 /* CourseSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3272CB98B890063FFD1 /* CourseSection.swift */; };
+		8969F4B02CB98B890063FFD1 /* CourseAlertNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3292CB98B890063FFD1 /* CourseAlertNetworkManager.swift */; };
+		8969F4B12CB98B890063FFD1 /* CourseAlertCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F32B2CB98B890063FFD1 /* CourseAlertCell.swift */; };
+		8969F4B22CB98B890063FFD1 /* CourseAlertCreateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F32C2CB98B890063FFD1 /* CourseAlertCreateCell.swift */; };
+		8969F4B32CB98B890063FFD1 /* CourseAlertSettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F32D2CB98B890063FFD1 /* CourseAlertSettingsCell.swift */; };
+		8969F4B42CB98B890063FFD1 /* SearchResultsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F32E2CB98B890063FFD1 /* SearchResultsCell.swift */; };
+		8969F4B52CB98B890063FFD1 /* ZeroCourseAlertsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F32F2CB98B890063FFD1 /* ZeroCourseAlertsCell.swift */; };
+		8969F4B62CB98B890063FFD1 /* CoursesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3322CB98B890063FFD1 /* CoursesViewModel.swift */; };
+		8969F4B72CB98B890063FFD1 /* CoursesDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3342CB98B890063FFD1 /* CoursesDayView.swift */; };
+		8969F4B82CB98B890063FFD1 /* CoursesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3352CB98B890063FFD1 /* CoursesView.swift */; };
+		8969F4B92CB98B890063FFD1 /* CoursesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3362CB98B890063FFD1 /* CoursesViewController.swift */; };
+		8969F4BA2CB98B890063FFD1 /* DiningLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3392CB98B890063FFD1 /* DiningLoginController.swift */; };
+		8969F4BB2CB98B890063FFD1 /* CardHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F33B2CB98B890063FFD1 /* CardHeaderView.swift */; };
+		8969F4BC2CB98B890063FFD1 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F33C2CB98B890063FFD1 /* CardView.swift */; };
+		8969F4BD2CB98B890063FFD1 /* DiningAnalyticsGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F33E2CB98B890063FFD1 /* DiningAnalyticsGraph.swift */; };
+		8969F4BE2CB98B890063FFD1 /* DiningAnalyticsGraphBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F33F2CB98B890063FFD1 /* DiningAnalyticsGraphBox.swift */; };
+		8969F4BF2CB98B890063FFD1 /* PredictionsGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3402CB98B890063FFD1 /* PredictionsGraphView.swift */; };
+		8969F4C02CB98B890063FFD1 /* PredictionsGraphView+AxisLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3412CB98B890063FFD1 /* PredictionsGraphView+AxisLabels.swift */; };
+		8969F4C12CB98B890063FFD1 /* PredictionsGraphView+SmoothedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3422CB98B890063FFD1 /* PredictionsGraphView+SmoothedData.swift */; };
+		8969F4C22CB98B890063FFD1 /* VariableStepLineGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3432CB98B890063FFD1 /* VariableStepLineGraphView.swift */; };
+		8969F4C32CB98B890063FFD1 /* VariableStepLineGraphView+GraphEndpointPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3442CB98B890063FFD1 /* VariableStepLineGraphView+GraphEndpointPath.swift */; };
+		8969F4C42CB98B890063FFD1 /* VariableStepLineGraphView+PredictionSlopePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3452CB98B890063FFD1 /* VariableStepLineGraphView+PredictionSlopePath.swift */; };
+		8969F4C52CB98B890063FFD1 /* VariableStepLineGraphView+VariableStepGraphPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3462CB98B890063FFD1 /* VariableStepLineGraphView+VariableStepGraphPath.swift */; };
+		8969F4C62CB98B890063FFD1 /* AnalyticsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3482CB98B890063FFD1 /* AnalyticsCardView.swift */; };
+		8969F4C72CB98B890063FFD1 /* DiningBalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3492CB98B890063FFD1 /* DiningBalanceView.swift */; };
+		8969F4C82CB98B890063FFD1 /* DiningVenueDetailHoursView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F34B2CB98B890063FFD1 /* DiningVenueDetailHoursView.swift */; };
+		8969F4C92CB98B890063FFD1 /* DiningVenueDetailLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F34C2CB98B890063FFD1 /* DiningVenueDetailLocationView.swift */; };
+		8969F4CA2CB98B890063FFD1 /* DiningVenueDetailMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F34D2CB98B890063FFD1 /* DiningVenueDetailMenuView.swift */; };
+		8969F4CB2CB98B890063FFD1 /* DiningVenueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F34E2CB98B890063FFD1 /* DiningVenueDetailView.swift */; };
+		8969F4CC2CB98B890063FFD1 /* MenuDisclosureGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F34F2CB98B890063FFD1 /* MenuDisclosureGroup.swift */; };
+		8969F4CD2CB98B890063FFD1 /* DiningVenueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3522CB98B890063FFD1 /* DiningVenueView.swift */; };
+		8969F4CE2CB98B890063FFD1 /* DiningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3552CB98B890063FFD1 /* DiningView.swift */; };
+		8969F4CF2CB98B890063FFD1 /* DiningViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3562CB98B890063FFD1 /* DiningViewHeader.swift */; };
+		8969F4D02CB98B890063FFD1 /* DiningAnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3582CB98B890063FFD1 /* DiningAnalyticsView.swift */; };
+		8969F4D12CB98B890063FFD1 /* DiningLoginNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3592CB98B890063FFD1 /* DiningLoginNavigationView.swift */; };
+		8969F4D22CB98B890063FFD1 /* DiningLoginViewSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F35A2CB98B890063FFD1 /* DiningLoginViewSwiftUI.swift */; };
+		8969F4D32CB98B890063FFD1 /* DiningSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F35B2CB98B890063FFD1 /* DiningSettingsView.swift */; };
+		8969F4D42CB98B890063FFD1 /* DiningViewControllerSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F35C2CB98B890063FFD1 /* DiningViewControllerSwiftUI.swift */; };
+		8969F4D52CB98B890063FFD1 /* DiningViewModelSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F35D2CB98B890063FFD1 /* DiningViewModelSwiftUI.swift */; };
+		8969F4D62CB98B890063FFD1 /* DiningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F35F2CB98B890063FFD1 /* DiningCell.swift */; };
+		8969F4D72CB98B890063FFD1 /* EventsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3622CB98B890063FFD1 /* EventsAPI.swift */; };
+		8969F4D82CB98B890063FFD1 /* PennEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3632CB98B890063FFD1 /* PennEvents.swift */; };
+		8969F4D92CB98B890063FFD1 /* PennEventsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3642CB98B890063FFD1 /* PennEventsTableViewCell.swift */; };
+		8969F4DA2CB98B890063FFD1 /* PennEventsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3652CB98B890063FFD1 /* PennEventsTableViewController.swift */; };
+		8969F4DB2CB98B890063FFD1 /* FitnessRoomRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3672CB98B890063FFD1 /* FitnessRoomRow.swift */; };
+		8969F4DC2CB98B890063FFD1 /* FitnessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3682CB98B890063FFD1 /* FitnessSettingsView.swift */; };
+		8969F4DD2CB98B890063FFD1 /* FitnessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3692CB98B890063FFD1 /* FitnessView.swift */; };
+		8969F4DE2CB98B890063FFD1 /* FitnessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F36A2CB98B890063FFD1 /* FitnessViewController.swift */; };
+		8969F4DF2CB98B890063FFD1 /* AnnouncementHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F36C2CB98B890063FFD1 /* AnnouncementHeaderView.swift */; };
+		8969F4E02CB98B890063FFD1 /* GenericControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F36D2CB98B890063FFD1 /* GenericControllers.swift */; };
+		8969F4E12CB98B890063FFD1 /* MoveableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F36E2CB98B890063FFD1 /* MoveableTableViewController.swift */; };
+		8969F4E22CB98B890063FFD1 /* ModularTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3702CB98B890063FFD1 /* ModularTableView.swift */; };
+		8969F4E32CB98B890063FFD1 /* ModularTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3712CB98B890063FFD1 /* ModularTableViewCell.swift */; };
+		8969F4E42CB98B890063FFD1 /* ModularTableViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3722CB98B890063FFD1 /* ModularTableViewItem.swift */; };
+		8969F4E52CB98B890063FFD1 /* ModularTableViewItemTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3732CB98B890063FFD1 /* ModularTableViewItemTypes.swift */; };
+		8969F4E62CB98B890063FFD1 /* ModularTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3742CB98B890063FFD1 /* ModularTableViewModel.swift */; };
+		8969F4E72CB98B890063FFD1 /* FeedAnalyticsEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3762CB98B890063FFD1 /* FeedAnalyticsEngine.swift */; };
+		8969F4E82CB98B890063FFD1 /* FirebaseAnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3772CB98B890063FFD1 /* FirebaseAnalyticsManager.swift */; };
+		8969F4E92CB98B890063FFD1 /* ImageNetworkingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3782CB98B890063FFD1 /* ImageNetworkingManager.swift */; };
+		8969F4EA2CB98B890063FFD1 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3792CB98B890063FFD1 /* Networking.swift */; };
+		8969F4EB2CB98B890063FFD1 /* UserDBManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F37A2CB98B890063FFD1 /* UserDBManager.swift */; };
+		8969F4EC2CB98B890063FFD1 /* AlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F37C2CB98B890063FFD1 /* AlertModifier.swift */; };
+		8969F4ED2CB98B890063FFD1 /* BetaBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F37D2CB98B890063FFD1 /* BetaBadge.swift */; };
+		8969F4EE2CB98B890063FFD1 /* CustomPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F37E2CB98B890063FFD1 /* CustomPopupView.swift */; };
+		8969F4EF2CB98B890063FFD1 /* FadingScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F37F2CB98B890063FFD1 /* FadingScrollView.swift */; };
+		8969F4F02CB98B890063FFD1 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3802CB98B890063FFD1 /* SafariView.swift */; };
+		8969F4F12CB98B890063FFD1 /* UIKit Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3812CB98B890063FFD1 /* UIKit Views.swift */; };
+		8969F4F22CB98B890063FFD1 /* KeychainAccessible+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3832CB98B890063FFD1 /* KeychainAccessible+Extensions.swift */; };
+		8969F4F32CB98B890063FFD1 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3842CB98B890063FFD1 /* Protocols.swift */; };
+		8969F4F42CB98B890063FFD1 /* UserDefaults + Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3852CB98B890063FFD1 /* UserDefaults + Helpers.swift */; };
+		8969F4F52CB98B890063FFD1 /* GSRGroupConfirmBookingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3872CB98B890063FFD1 /* GSRGroupConfirmBookingController.swift */; };
+		8969F4F62CB98B890063FFD1 /* GSRGroupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3882CB98B890063FFD1 /* GSRGroupController.swift */; };
+		8969F4F72CB98B890063FFD1 /* GSRGroupInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3892CB98B890063FFD1 /* GSRGroupInviteViewController.swift */; };
+		8969F4F82CB98B890063FFD1 /* GSRGroupNewIntialController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F38A2CB98B890063FFD1 /* GSRGroupNewIntialController.swift */; };
+		8969F4F92CB98B890063FFD1 /* GSRManageGroupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F38B2CB98B890063FFD1 /* GSRManageGroupController.swift */; };
+		8969F4FA2CB98B890063FFD1 /* GSRBookable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F38D2CB98B890063FFD1 /* GSRBookable.swift */; };
+		8969F4FB2CB98B890063FFD1 /* GSRController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F38E2CB98B890063FFD1 /* GSRController.swift */; };
+		8969F4FC2CB98B890063FFD1 /* GSRDeletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F38F2CB98B890063FFD1 /* GSRDeletable.swift */; };
+		8969F4FD2CB98B890063FFD1 /* GSRLocationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3902CB98B890063FFD1 /* GSRLocationsController.swift */; };
+		8969F4FE2CB98B890063FFD1 /* GSRReservationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3912CB98B890063FFD1 /* GSRReservationsController.swift */; };
+		8969F4FF2CB98B890063FFD1 /* GSRTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3922CB98B890063FFD1 /* GSRTabController.swift */; };
+		8969F5002CB98B890063FFD1 /* GSRAPIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3942CB98B890063FFD1 /* GSRAPIResponse.swift */; };
+		8969F5012CB98B890063FFD1 /* GSRBooking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3952CB98B890063FFD1 /* GSRBooking.swift */; };
+		8969F5022CB98B890063FFD1 /* GSRDateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3962CB98B890063FFD1 /* GSRDateHandler.swift */; };
+		8969F5032CB98B890063FFD1 /* GSRGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3972CB98B890063FFD1 /* GSRGroup.swift */; };
+		8969F5042CB98B890063FFD1 /* GSRGroupUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3982CB98B890063FFD1 /* GSRGroupUser.swift */; };
+		8969F5052CB98B890063FFD1 /* GSRLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3992CB98B890063FFD1 /* GSRLocation.swift */; };
+		8969F5062CB98B890063FFD1 /* GSRLocationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F39A2CB98B890063FFD1 /* GSRLocationModel.swift */; };
+		8969F5072CB98B890063FFD1 /* GSRReservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F39B2CB98B890063FFD1 /* GSRReservation.swift */; };
+		8969F5082CB98B890063FFD1 /* GSRRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F39C2CB98B890063FFD1 /* GSRRoom.swift */; };
+		8969F5092CB98B890063FFD1 /* GSRTimeSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F39D2CB98B890063FFD1 /* GSRTimeSlot.swift */; };
+		8969F50A2CB98B890063FFD1 /* GSRGroupNetworkManager..swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F39F2CB98B890063FFD1 /* GSRGroupNetworkManager..swift */; };
+		8969F50B2CB98B890063FFD1 /* GSRNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A02CB98B890063FFD1 /* GSRNetworkManager.swift */; };
+		8969F50C2CB98B890063FFD1 /* GSRManageGroupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A22CB98B890063FFD1 /* GSRManageGroupViewModel.swift */; };
+		8969F50D2CB98B890063FFD1 /* GSRViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A32CB98B890063FFD1 /* GSRViewModel.swift */; };
+		8969F50E2CB98B890063FFD1 /* CreateGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A52CB98B890063FFD1 /* CreateGroupCell.swift */; };
+		8969F50F2CB98B890063FFD1 /* GroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A62CB98B890063FFD1 /* GroupCell.swift */; };
+		8969F5102CB98B890063FFD1 /* GroupHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A72CB98B890063FFD1 /* GroupHeaderCell.swift */; };
+		8969F5112CB98B890063FFD1 /* GroupIndividualSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A82CB98B890063FFD1 /* GroupIndividualSettingView.swift */; };
+		8969F5122CB98B890063FFD1 /* GroupInviteUserCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3A92CB98B890063FFD1 /* GroupInviteUserCell.swift */; };
+		8969F5132CB98B890063FFD1 /* GroupManageButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3AA2CB98B890063FFD1 /* GroupManageButtonCell.swift */; };
+		8969F5142CB98B890063FFD1 /* GroupMemberCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3AB2CB98B890063FFD1 /* GroupMemberCell.swift */; };
+		8969F5152CB98B890063FFD1 /* GroupSettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3AC2CB98B890063FFD1 /* GroupSettingsCell.swift */; };
+		8969F5162CB98B890063FFD1 /* GSRColorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3AD2CB98B890063FFD1 /* GSRColorCell.swift */; };
+		8969F5172CB98B890063FFD1 /* GSRGroupIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3AE2CB98B890063FFD1 /* GSRGroupIconView.swift */; };
+		8969F5182CB98B890063FFD1 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B02CB98B890063FFD1 /* EmptyView.swift */; };
+		8969F5192CB98B890063FFD1 /* GSRClosedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B12CB98B890063FFD1 /* GSRClosedView.swift */; };
+		8969F51A2CB98B890063FFD1 /* GSRLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B22CB98B890063FFD1 /* GSRLocationCell.swift */; };
+		8969F51B2CB98B890063FFD1 /* GSRRangeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B32CB98B890063FFD1 /* GSRRangeSlider.swift */; };
+		8969F51C2CB98B890063FFD1 /* GSRTimeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B42CB98B890063FFD1 /* GSRTimeCell.swift */; };
+		8969F51D2CB98B890063FFD1 /* NoReservationsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B52CB98B890063FFD1 /* NoReservationsCell.swift */; };
+		8969F51E2CB98B890063FFD1 /* ReservationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B62CB98B890063FFD1 /* ReservationCell.swift */; };
+		8969F51F2CB98B890063FFD1 /* RoomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B72CB98B890063FFD1 /* RoomCell.swift */; };
+		8969F5202CB98B890063FFD1 /* RangeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3B92CB98B890063FFD1 /* RangeSlider.swift */; };
+		8969F5212CB98B890063FFD1 /* TextLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3BA2CB98B890063FFD1 /* TextLayer.swift */; };
+		8969F5222CB98B890063FFD1 /* ThumbLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3BB2CB98B890063FFD1 /* ThumbLayer.swift */; };
+		8969F5232CB98B890063FFD1 /* TrackLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3BC2CB98B890063FFD1 /* TrackLayer.swift */; };
+		8969F5242CB98B890063FFD1 /* CalendarAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3BF2CB98B890063FFD1 /* CalendarAPI.swift */; };
+		8969F5252CB98B890063FFD1 /* CalendarEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C02CB98B890063FFD1 /* CalendarEvent.swift */; };
+		8969F5262CB98B890063FFD1 /* HomeCalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C12CB98B890063FFD1 /* HomeCalendarCell.swift */; };
+		8969F5272CB98B890063FFD1 /* HomeCalendarCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C22CB98B890063FFD1 /* HomeCalendarCellItem.swift */; };
+		8969F5282CB98B890063FFD1 /* UniversityNotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C32CB98B890063FFD1 /* UniversityNotificationCell.swift */; };
+		8969F5292CB98B890063FFD1 /* HomeDiningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C52CB98B890063FFD1 /* HomeDiningCell.swift */; };
+		8969F52A2CB98B890063FFD1 /* HomeDiningCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C62CB98B890063FFD1 /* HomeDiningCellItem.swift */; };
+		8969F52B2CB98B890063FFD1 /* FeatureAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C82CB98B890063FFD1 /* FeatureAnnouncement.swift */; };
+		8969F52C2CB98B890063FFD1 /* HomeFeatureCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3C92CB98B890063FFD1 /* HomeFeatureCell.swift */; };
+		8969F52D2CB98B890063FFD1 /* HomeFeatureCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3CA2CB98B890063FFD1 /* HomeFeatureCellItem.swift */; };
+		8969F52E2CB98B890063FFD1 /* GSRGroupInviteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3CC2CB98B890063FFD1 /* GSRGroupInviteCell.swift */; };
+		8969F52F2CB98B890063FFD1 /* HomeGroupInvitesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3CD2CB98B890063FFD1 /* HomeGroupInvitesCell.swift */; };
+		8969F5302CB98B890063FFD1 /* HomeGroupInvitesCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3CE2CB98B890063FFD1 /* HomeGroupInvitesCellItem.swift */; };
+		8969F5312CB98B890063FFD1 /* BookingRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D02CB98B890063FFD1 /* BookingRowCell.swift */; };
+		8969F5322CB98B890063FFD1 /* HomeGSRBookingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D22CB98B890063FFD1 /* HomeGSRBookingButton.swift */; };
+		8969F5332CB98B890063FFD1 /* HomeGSRCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D32CB98B890063FFD1 /* HomeGSRCellItem.swift */; };
+		8969F5342CB98B890063FFD1 /* HomeStudyRoomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D42CB98B890063FFD1 /* HomeStudyRoomCell.swift */; };
+		8969F5352CB98B890063FFD1 /* HomeGSRLocationsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D62CB98B890063FFD1 /* HomeGSRLocationsCell.swift */; };
+		8969F5362CB98B890063FFD1 /* HomeGSRLocationsCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D72CB98B890063FFD1 /* HomeGSRLocationsCellItem.swift */; };
+		8969F5372CB98B890063FFD1 /* HomeReservationsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3D92CB98B890063FFD1 /* HomeReservationsCell.swift */; };
+		8969F5382CB98B890063FFD1 /* HomeReservationsCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3DA2CB98B890063FFD1 /* HomeReservationsCellItem.swift */; };
+		8969F5392CB98B890063FFD1 /* HomeLaundryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3DC2CB98B890063FFD1 /* HomeLaundryCell.swift */; };
+		8969F53A2CB98B890063FFD1 /* HomeLaundryCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3DD2CB98B890063FFD1 /* HomeLaundryCellItem.swift */; };
+		8969F53B2CB98B890063FFD1 /* HomeNewsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3DF2CB98B890063FFD1 /* HomeNewsCell.swift */; };
+		8969F53C2CB98B890063FFD1 /* HomeNewsCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E02CB98B890063FFD1 /* HomeNewsCellItem.swift */; };
+		8969F53D2CB98B890063FFD1 /* NativeNewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E12CB98B890063FFD1 /* NativeNewsViewController.swift */; };
+		8969F53E2CB98B890063FFD1 /* NewsArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E22CB98B890063FFD1 /* NewsArticle.swift */; };
+		8969F53F2CB98B890063FFD1 /* HomePollsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E42CB98B890063FFD1 /* HomePollsCell.swift */; };
+		8969F5402CB98B890063FFD1 /* HomePollsCellFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E52CB98B890063FFD1 /* HomePollsCellFooter.swift */; };
+		8969F5412CB98B890063FFD1 /* HomePollsCellHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E62CB98B890063FFD1 /* HomePollsCellHeader.swift */; };
+		8969F5422CB98B890063FFD1 /* HomePollsCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E72CB98B890063FFD1 /* HomePollsCellItem.swift */; };
+		8969F5432CB98B890063FFD1 /* PollOptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3E82CB98B890063FFD1 /* PollOptionCell.swift */; };
+		8969F5442CB98B890063FFD1 /* HomePostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3EA2CB98B890063FFD1 /* HomePostCell.swift */; };
+		8969F5452CB98B890063FFD1 /* HomePostCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3EB2CB98B890063FFD1 /* HomePostCellItem.swift */; };
+		8969F5462CB98B890063FFD1 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3EC2CB98B890063FFD1 /* Post.swift */; };
+		8969F5472CB98B890063FFD1 /* HomeFlingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3EE2CB98B890063FFD1 /* HomeFlingCell.swift */; };
+		8969F5482CB98B890063FFD1 /* HomeFlingCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3EF2CB98B890063FFD1 /* HomeFlingCellItem.swift */; };
+		8969F5492CB98B890063FFD1 /* HomeUpdateCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F12CB98B890063FFD1 /* HomeUpdateCellItem.swift */; };
+		8969F54A2CB98B890063FFD1 /* HomeCellConformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F32CB98B890063FFD1 /* HomeCellConformable.swift */; };
+		8969F54B2CB98B890063FFD1 /* HomeCellHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F42CB98B890063FFD1 /* HomeCellHeader.swift */; };
+		8969F54C2CB98B890063FFD1 /* HomeCellProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F52CB98B890063FFD1 /* HomeCellProtocols.swift */; };
+		8969F54D2CB98B890063FFD1 /* HomeCellSafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F62CB98B890063FFD1 /* HomeCellSafeArea.swift */; };
+		8969F54E2CB98B890063FFD1 /* BuildingMapWebviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F82CB98B890063FFD1 /* BuildingMapWebviewController.swift */; };
+		8969F54F2CB98B890063FFD1 /* DiningCellSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3F92CB98B890063FFD1 /* DiningCellSettingsController.swift */; };
+		8969F5502CB98B890063FFD1 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3FA2CB98B890063FFD1 /* HomeViewController.swift */; };
+		8969F5512CB98B890063FFD1 /* HomeViewController + Delegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3FB2CB98B890063FFD1 /* HomeViewController + Delegates.swift */; };
+		8969F5522CB98B890063FFD1 /* HomeCellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3FD2CB98B890063FFD1 /* HomeCellItem.swift */; };
+		8969F5532CB98B890063FFD1 /* HomeItemTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3FE2CB98B890063FFD1 /* HomeItemTypes.swift */; };
+		8969F5542CB98B890063FFD1 /* HomeTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F3FF2CB98B890063FFD1 /* HomeTableViewModel.swift */; };
+		8969F5552CB98B890063FFD1 /* HomeAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4012CB98B890063FFD1 /* HomeAPIService.swift */; };
+		8969F5562CB98B890063FFD1 /* CalendarCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4032CB98B890063FFD1 /* CalendarCardView.swift */; };
+		8969F5572CB98B890063FFD1 /* HomeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4042CB98B890063FFD1 /* HomeCardView.swift */; };
+		8969F5582CB98B890063FFD1 /* HomeSublettingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4052CB98B890063FFD1 /* HomeSublettingBanner.swift */; };
+		8969F5592CB98B890063FFD1 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4062CB98B890063FFD1 /* HomeView.swift */; };
+		8969F55A2CB98B890063FFD1 /* HomeViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4072CB98B890063FFD1 /* HomeViewData.swift */; };
+		8969F55B2CB98B890063FFD1 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4082CB98B890063FFD1 /* HomeViewModel.swift */; };
+		8969F55C2CB98B890063FFD1 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F40A2CB98B890063FFD1 /* Model.swift */; };
+		8969F55D2CB98B890063FFD1 /* AddLaundryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F40C2CB98B890063FFD1 /* AddLaundryCell.swift */; };
+		8969F55E2CB98B890063FFD1 /* LaundryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F40D2CB98B890063FFD1 /* LaundryCell.swift */; };
+		8969F55F2CB98B890063FFD1 /* LaundryCell + Graph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F40E2CB98B890063FFD1 /* LaundryCell + Graph.swift */; };
+		8969F5602CB98B890063FFD1 /* LaundryGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F40F2CB98B890063FFD1 /* LaundryGraphView.swift */; };
+		8969F5612CB98B890063FFD1 /* LaundryMachineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4102CB98B890063FFD1 /* LaundryMachineCell.swift */; };
+		8969F5622CB98B890063FFD1 /* LaundryMachinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4112CB98B890063FFD1 /* LaundryMachinesView.swift */; };
+		8969F5632CB98B890063FFD1 /* LaundryMachineCellTappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4132CB98B890063FFD1 /* LaundryMachineCellTappable.swift */; };
+		8969F5642CB98B890063FFD1 /* LaundryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4142CB98B890063FFD1 /* LaundryTableViewController.swift */; };
+		8969F5652CB98B890063FFD1 /* RoomSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4152CB98B890063FFD1 /* RoomSelectionViewController.swift */; };
+		8969F5662CB98B890063FFD1 /* LaundryNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4172CB98B890063FFD1 /* LaundryNotificationCenter.swift */; };
+		8969F5672CB98B890063FFD1 /* LaundryRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4182CB98B890063FFD1 /* LaundryRoom.swift */; };
+		8969F5682CB98B890063FFD1 /* LaundryAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F41A2CB98B890063FFD1 /* LaundryAPIService.swift */; };
+		8969F5692CB98B890063FFD1 /* RoomSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F41C2CB98B890063FFD1 /* RoomSelectionView.swift */; };
+		8969F56A2CB98B890063FFD1 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F41F2CB98B890063FFD1 /* Account.swift */; };
+		8969F56B2CB98B890063FFD1 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4202CB98B890063FFD1 /* AuthManager.swift */; };
+		8969F56C2CB98B890063FFD1 /* CampusExpressLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4212CB98B890063FFD1 /* CampusExpressLoginController.swift */; };
+		8969F56D2CB98B890063FFD1 /* CampusExpressNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4222CB98B890063FFD1 /* CampusExpressNetworkManager.swift */; };
+		8969F56E2CB98B890063FFD1 /* Degree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4232CB98B890063FFD1 /* Degree.swift */; };
+		8969F56F2CB98B890063FFD1 /* LabsLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4242CB98B890063FFD1 /* LabsLoginController.swift */; };
+		8969F5702CB98B890063FFD1 /* LabsLoginSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4252CB98B890063FFD1 /* LabsLoginSwiftUI.swift */; };
+		8969F5712CB98B890063FFD1 /* LoggedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4262CB98B890063FFD1 /* LoggedOutView.swift */; };
+		8969F5722CB98B890063FFD1 /* PathAtPennNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4272CB98B890063FFD1 /* PathAtPennNetworkManager.swift */; };
+		8969F5732CB98B890063FFD1 /* PennCashNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4282CB98B890063FFD1 /* PennCashNetworkManager.swift */; };
+		8969F5742CB98B890063FFD1 /* PennInTouchNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4292CB98B890063FFD1 /* PennInTouchNetworkManager.swift */; };
+		8969F5752CB98B890063FFD1 /* AddressMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F42B2CB98B890063FFD1 /* AddressMapView.swift */; };
+		8969F5762CB98B890063FFD1 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F42C2CB98B890063FFD1 /* MapViewController.swift */; };
+		8969F5772CB98B890063FFD1 /* PennCoordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F42D2CB98B890063FFD1 /* PennCoordinate.swift */; };
+		8969F5782CB98B890063FFD1 /* PacCodeNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F42F2CB98B890063FFD1 /* PacCodeNetworkManager.swift */; };
+		8969F5792CB98B890063FFD1 /* PacCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4302CB98B890063FFD1 /* PacCodeViewController.swift */; };
+		8969F57A2CB98B890063FFD1 /* ProfilePageNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4322CB98B890063FFD1 /* ProfilePageNetworkManager.swift */; };
+		8969F57B2CB98B890063FFD1 /* InfoTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4342CB98B890063FFD1 /* InfoTableViewController.swift */; };
+		8969F57C2CB98B890063FFD1 /* InfoTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4352CB98B890063FFD1 /* InfoTableViewModel.swift */; };
+		8969F57D2CB98B890063FFD1 /* ProfilePageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4362CB98B890063FFD1 /* ProfilePageTableViewCell.swift */; };
+		8969F57E2CB98B890063FFD1 /* ProfilePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4372CB98B890063FFD1 /* ProfilePageViewController.swift */; };
+		8969F57F2CB98B890063FFD1 /* ProfilePageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4382CB98B890063FFD1 /* ProfilePageViewModel.swift */; };
+		8969F5802CB98B890063FFD1 /* ProfilePictureTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4392CB98B890063FFD1 /* ProfilePictureTableViewCell.swift */; };
+		8969F5812CB98B890063FFD1 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F43B2CB98B890063FFD1 /* AboutViewController.swift */; };
+		8969F5822CB98B890063FFD1 /* HeaderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F43C2CB98B890063FFD1 /* HeaderViewCell.swift */; };
+		8969F5832CB98B890063FFD1 /* MoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F43D2CB98B890063FFD1 /* MoreCell.swift */; };
+		8969F5842CB98B890063FFD1 /* MoreHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F43E2CB98B890063FFD1 /* MoreHeaderView.swift */; };
+		8969F5852CB98B890063FFD1 /* MoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F43F2CB98B890063FFD1 /* MoreView.swift */; };
+		8969F5862CB98B890063FFD1 /* MoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4402CB98B890063FFD1 /* MoreViewController.swift */; };
+		8969F5872CB98B890063FFD1 /* ProfileRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4412CB98B890063FFD1 /* ProfileRowView.swift */; };
+		8969F5882CB98B890063FFD1 /* NewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4432CB98B890063FFD1 /* NewsViewController.swift */; };
+		8969F5892CB98B890063FFD1 /* NotificationAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4452CB98B890063FFD1 /* NotificationAPIModel.swift */; };
+		8969F58A2CB98B890063FFD1 /* NotificationsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4462CB98B890063FFD1 /* NotificationsSetting.swift */; };
+		8969F58B2CB98B890063FFD1 /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4482CB98B890063FFD1 /* NotificationsView.swift */; };
+		8969F58C2CB98B890063FFD1 /* NotificationsViewControllerSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4492CB98B890063FFD1 /* NotificationsViewControllerSwiftUI.swift */; };
+		8969F58D2CB98B890063FFD1 /* NotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F44A2CB98B890063FFD1 /* NotificationViewModel.swift */; };
+		8969F58E2CB98B890063FFD1 /* NotificationPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F44C2CB98B890063FFD1 /* NotificationPreference.swift */; };
+		8969F58F2CB98B890063FFD1 /* NotificationRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F44D2CB98B890063FFD1 /* NotificationRequestable.swift */; };
+		8969F5902CB98B890063FFD1 /* NotificationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F44E2CB98B890063FFD1 /* NotificationsTableViewCell.swift */; };
+		8969F5912CB98B890063FFD1 /* NotificationsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F44F2CB98B890063FFD1 /* NotificationsTableViewController.swift */; };
+		8969F5922CB98B890063FFD1 /* OnboardingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4512CB98B890063FFD1 /* OnboardingController.swift */; };
+		8969F5932CB98B890063FFD1 /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4522CB98B890063FFD1 /* Page.swift */; };
+		8969F5942CB98B890063FFD1 /* PageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4532CB98B890063FFD1 /* PageCell.swift */; };
+		8969F5952CB98B890063FFD1 /* SAConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4542CB98B890063FFD1 /* SAConfettiView.swift */; };
+		8969F5962CB98B890063FFD1 /* SelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4552CB98B890063FFD1 /* SelectionCell.swift */; };
+		8969F5972CB98B890063FFD1 /* AIChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4572CB98B890063FFD1 /* AIChatModel.swift */; };
+		8969F5982CB98B890063FFD1 /* AIChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4582CB98B890063FFD1 /* AIChatView.swift */; };
+		8969F5992CB98B890063FFD1 /* AIChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4592CB98B890063FFD1 /* AIChatViewModel.swift */; };
+		8969F59A2CB98B890063FFD1 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F45A2CB98B890063FFD1 /* ChatMessage.swift */; };
+		8969F59B2CB98B890063FFD1 /* ChatMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F45B2CB98B890063FFD1 /* ChatMessageView.swift */; };
+		8969F59C2CB98B890063FFD1 /* PollQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F45D2CB98B890063FFD1 /* PollQuestion.swift */; };
+		8969F59D2CB98B890063FFD1 /* PollsNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F45F2CB98B890063FFD1 /* PollsNetworkManager.swift */; };
+		8969F59E2CB98B890063FFD1 /* PollsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4612CB98B890063FFD1 /* PollsView.swift */; };
+		8969F59F2CB98B890063FFD1 /* PollsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4622CB98B890063FFD1 /* PollsViewController.swift */; };
+		8969F5A02CB98B890063FFD1 /* PollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4632CB98B890063FFD1 /* PollView.swift */; };
+		8969F5A12CB98B890063FFD1 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4652CB98B890063FFD1 /* PreferencesView.swift */; };
+		8969F5A22CB98B890063FFD1 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4662CB98B890063FFD1 /* PreferencesViewController.swift */; };
+		8969F5A32CB98B890063FFD1 /* PermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4682CB98B890063FFD1 /* PermissionView.swift */; };
+		8969F5A42CB98B890063FFD1 /* PrivacyPermissionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4692CB98B890063FFD1 /* PrivacyPermissionDelegate.swift */; };
+		8969F5A52CB98B890063FFD1 /* PrivacyPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F46A2CB98B890063FFD1 /* PrivacyPreference.swift */; };
+		8969F5A62CB98B890063FFD1 /* PrivacyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F46B2CB98B890063FFD1 /* PrivacyTableViewCell.swift */; };
+		8969F5A72CB98B890063FFD1 /* PrivacyTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F46C2CB98B890063FFD1 /* PrivacyTableViewController.swift */; };
+		8969F5A82CB98B890063FFD1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F46E2CB98B890063FFD1 /* AppDelegate.swift */; };
+		8969F5A92CB98B890063FFD1 /* AppDelegate+NotificationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F46F2CB98B890063FFD1 /* AppDelegate+NotificationExtension.swift */; };
+		8969F5AA2CB98B890063FFD1 /* ControllerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4702CB98B890063FFD1 /* ControllerModel.swift */; };
+		8969F5AB2CB98B890063FFD1 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4712CB98B890063FFD1 /* Environment.swift */; };
+		8969F5AC2CB98B890063FFD1 /* Features.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4722CB98B890063FFD1 /* Features.swift */; };
+		8969F5AD2CB98B890063FFD1 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4732CB98B890063FFD1 /* MainTabView.swift */; };
+		8969F5AE2CB98B890063FFD1 /* PennMobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4742CB98B890063FFD1 /* PennMobile.swift */; };
+		8969F5AF2CB98B890063FFD1 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4752CB98B890063FFD1 /* RootView.swift */; };
+		8969F5B02CB98B890063FFD1 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4762CB98B890063FFD1 /* RootViewController.swift */; };
+		8969F5B12CB98B890063FFD1 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4772CB98B890063FFD1 /* SplashViewController.swift */; };
+		8969F5B22CB98B890063FFD1 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4782CB98B890063FFD1 /* TabBarController.swift */; };
+		8969F5B32CB98B890063FFD1 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4792CB98B890063FFD1 /* Toasts.swift */; };
+		8969F5B42CB98B890063FFD1 /* MyListingsActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F47B2CB98B890063FFD1 /* MyListingsActivity.swift */; };
+		8969F5B52CB98B890063FFD1 /* NewListingForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F47C2CB98B890063FFD1 /* NewListingForm.swift */; };
+		8969F5B62CB98B890063FFD1 /* MarketplaceFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F47E2CB98B890063FFD1 /* MarketplaceFilterView.swift */; };
+		8969F5B72CB98B890063FFD1 /* MarketplaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F47F2CB98B890063FFD1 /* MarketplaceView.swift */; };
+		8969F5B82CB98B890063FFD1 /* SubletCandidatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4802CB98B890063FFD1 /* SubletCandidatesView.swift */; };
+		8969F5B92CB98B890063FFD1 /* SubletDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4812CB98B890063FFD1 /* SubletDetailView.swift */; };
+		8969F5BA2CB98B890063FFD1 /* SubletDisplayRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4822CB98B890063FFD1 /* SubletDisplayRow.swift */; };
+		8969F5BB2CB98B890063FFD1 /* SubletInterestForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4832CB98B890063FFD1 /* SubletInterestForm.swift */; };
+		8969F5BC2CB98B890063FFD1 /* SubletMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4842CB98B890063FFD1 /* SubletMapView.swift */; };
+		8969F5BD2CB98B890063FFD1 /* SublettingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4852CB98B890063FFD1 /* SublettingAPI.swift */; };
+		8969F5BE2CB98B890063FFD1 /* SublettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F4862CB98B890063FFD1 /* SublettingViewModel.swift */; };
+		8969F5BF2CB98B890063FFD1 /* ScannerDuplicate.ahap in Resources */ = {isa = PBXBuildFile; fileRef = 8969F30F2CB98B890063FFD1 /* ScannerDuplicate.ahap */; };
+		8969F5C02CB98B890063FFD1 /* ScannerError.ahap in Resources */ = {isa = PBXBuildFile; fileRef = 8969F3102CB98B890063FFD1 /* ScannerError.ahap */; };
+		8969F5C12CB98B890063FFD1 /* ScannerInvalid.ahap in Resources */ = {isa = PBXBuildFile; fileRef = 8969F3112CB98B890063FFD1 /* ScannerInvalid.ahap */; };
+		8969F5C22CB98B890063FFD1 /* ScannerValid.ahap in Resources */ = {isa = PBXBuildFile; fileRef = 8969F3132CB98B890063FFD1 /* ScannerValid.ahap */; };
+		8969F5C32CB98B890063FFD1 /* mock_menu.json in Resources */ = {isa = PBXBuildFile; fileRef = 8969F3502CB98B890063FFD1 /* mock_menu.json */; };
+		8969F5C42CB98B890063FFD1 /* sample-dining-venue.json in Resources */ = {isa = PBXBuildFile; fileRef = 8969F3532CB98B890063FFD1 /* sample-dining-venue.json */; };
+		8969F5C52CB98B890063FFD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8969F4882CB98B890063FFD1 /* GoogleService-Info.plist */; };
+		8969F5C72CB98B890063FFD1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8969F48D2CB98B890063FFD1 /* Assets.xcassets */; };
+		8969F5E12CB98B900063FFD1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8969F5D82CB98B900063FFD1 /* Assets.xcassets */; };
+		8969F5E32CB98B900063FFD1 /* CoursesDayWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5CC2CB98B900063FFD1 /* CoursesDayWidget.swift */; };
+		8969F5E42CB98B900063FFD1 /* CoursesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5CD2CB98B900063FFD1 /* CoursesProvider.swift */; };
+		8969F5E52CB98B900063FFD1 /* DiningAnalyticsHomeWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5CF2CB98B900063FFD1 /* DiningAnalyticsHomeWidget.swift */; };
+		8969F5E62CB98B900063FFD1 /* DiningAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5D02CB98B900063FFD1 /* DiningAnalyticsProvider.swift */; };
+		8969F5E72CB98B900063FFD1 /* DiningHoursProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5D22CB98B900063FFD1 /* DiningHoursProvider.swift */; };
+		8969F5E82CB98B900063FFD1 /* DiningHoursWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5D32CB98B900063FFD1 /* DiningHoursWidget.swift */; };
+		8969F5E92CB98B900063FFD1 /* FitnessProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5D52CB98B900063FFD1 /* FitnessProvider.swift */; };
+		8969F5EA2CB98B900063FFD1 /* FitnessWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5D62CB98B900063FFD1 /* FitnessWidget.swift */; };
+		8969F5EB2CB98B900063FFD1 /* ConfigurationRepresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5D92CB98B900063FFD1 /* ConfigurationRepresenting.swift */; };
+		8969F5EC2CB98B900063FFD1 /* LaundryLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5DB2CB98B900063FFD1 /* LaundryLiveActivity.swift */; };
+		8969F5ED2CB98B900063FFD1 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5DC2CB98B900063FFD1 /* ViewExtensions.swift */; };
+		8969F5EE2CB98B900063FFD1 /* WidgetBackgroundTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5DD2CB98B900063FFD1 /* WidgetBackgroundTypeExtensions.swift */; };
+		8969F5EF2CB98B900063FFD1 /* WidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969F5DE2CB98B900063FFD1 /* WidgetBundle.swift */; };
 		898DB4912B2E7AA20027CC8F /* PennForms in Frameworks */ = {isa = PBXBuildFile; productRef = 898DB4902B2E7AA20027CC8F /* PennForms */; };
 		89EA262E290F9411008F26CF /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 89EA262D290F9411008F26CF /* Intents.intentdefinition */; };
 		89EA262F290F958B008F26CF /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 89EA262D290F9411008F26CF /* Intents.intentdefinition */; };
@@ -108,6 +466,374 @@
 		8932693328FC75A5003D4BF9 /* WidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8932693428FC75A5003D4BF9 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		8932693628FC75A5003D4BF9 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		8969F2AF2CB98B860063FFD1 /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
+		8969F2B02CB98B860063FFD1 /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
+		8969F2B22CB98B860063FFD1 /* DiningBalance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningBalance.swift; sourceTree = "<group>"; };
+		8969F2B32CB98B860063FFD1 /* DiningMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningMenu.swift; sourceTree = "<group>"; };
+		8969F2B42CB98B860063FFD1 /* DiningPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningPlan.swift; sourceTree = "<group>"; };
+		8969F2B52CB98B860063FFD1 /* DiningToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningToken.swift; sourceTree = "<group>"; };
+		8969F2B62CB98B860063FFD1 /* DiningVenue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenue.swift; sourceTree = "<group>"; };
+		8969F2B72CB98B860063FFD1 /* DiningVenue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiningVenue+Extensions.swift"; sourceTree = "<group>"; };
+		8969F2B82CB98B860063FFD1 /* PastDiningBalances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastDiningBalances.swift; sourceTree = "<group>"; };
+		8969F2BA2CB98B860063FFD1 /* DiningAnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsViewModel.swift; sourceTree = "<group>"; };
+		8969F2BB2CB98B860063FFD1 /* DiningAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAPI.swift; sourceTree = "<group>"; };
+		8969F2BC2CB98B860063FFD1 /* DiningVenueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenueRow.swift; sourceTree = "<group>"; };
+		8969F2BE2CB98B860063FFD1 /* FitnessAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessAPI.swift; sourceTree = "<group>"; };
+		8969F2BF2CB98B860063FFD1 /* FitnessGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessGraph.swift; sourceTree = "<group>"; };
+		8969F2C02CB98B860063FFD1 /* FitnessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessModel.swift; sourceTree = "<group>"; };
+		8969F2C22CB98B860063FFD1 /* BadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeView.swift; sourceTree = "<group>"; };
+		8969F2C32CB98B860063FFD1 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		8969F2C42CB98B860063FFD1 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
+		8969F2C52CB98B860063FFD1 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		8969F2C62CB98B860063FFD1 /* KeychainAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessible.swift; sourceTree = "<group>"; };
+		8969F2C72CB98B860063FFD1 /* MeterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeterView.swift; sourceTree = "<group>"; };
+		8969F2C82CB98B860063FFD1 /* PhoneNumberFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormat.swift; sourceTree = "<group>"; };
+		8969F2C92CB98B860063FFD1 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		8969F2CA2CB98B860063FFD1 /* SecureStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStore.swift; sourceTree = "<group>"; };
+		8969F2CB2CB98B860063FFD1 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
+		8969F2CC2CB98B860063FFD1 /* WidgetKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetKind.swift; sourceTree = "<group>"; };
+		8969F2CE2CB98B860063FFD1 /* LaundryAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryAttributes.swift; sourceTree = "<group>"; };
+		8969F2CF2CB98B860063FFD1 /* LaundryMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryMachine.swift; sourceTree = "<group>"; };
+		8969F2D12CB98B860063FFD1 /* Multipart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Multipart.swift; sourceTree = "<group>"; };
+		8969F2D22CB98B860063FFD1 /* NetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingError.swift; sourceTree = "<group>"; };
+		8969F2D42CB98B860063FFD1 /* SubletDisplayBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubletDisplayBox.swift; sourceTree = "<group>"; };
+		8969F2D52CB98B860063FFD1 /* SublettingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SublettingModels.swift; sourceTree = "<group>"; };
+		8969F2D72CB98B860063FFD1 /* PennMobileShared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PennMobileShared.h; sourceTree = "<group>"; };
+		8969F2FA2CB98B890063FFD1 /* OAuth2NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2NetworkManager.swift; sourceTree = "<group>"; };
+		8969F2FB2CB98B890063FFD1 /* PennAuthRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennAuthRequestable.swift; sourceTree = "<group>"; };
+		8969F2FC2CB98B890063FFD1 /* PennLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennLoginController.swift; sourceTree = "<group>"; };
+		8969F2FE2CB98B890063FFD1 /* BannerDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerDescription.swift; sourceTree = "<group>"; };
+		8969F2FF2CB98B890063FFD1 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
+		8969F3002CB98B890063FFD1 /* BannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewModel.swift; sourceTree = "<group>"; };
+		8969F3012CB98B890063FFD1 /* UserEngagementPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEngagementPopupView.swift; sourceTree = "<group>"; };
+		8969F3032CB98B890063FFD1 /* BuildingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingCell.swift; sourceTree = "<group>"; };
+		8969F3042CB98B890063FFD1 /* BuildingFoodMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingFoodMenuCell.swift; sourceTree = "<group>"; };
+		8969F3052CB98B890063FFD1 /* BuildingHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingHeaderCell.swift; sourceTree = "<group>"; };
+		8969F3062CB98B890063FFD1 /* BuildingHoursCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingHoursCell.swift; sourceTree = "<group>"; };
+		8969F3072CB98B890063FFD1 /* BuildingImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingImageCell.swift; sourceTree = "<group>"; };
+		8969F3082CB98B890063FFD1 /* BuildingMapCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingMapCell.swift; sourceTree = "<group>"; };
+		8969F3092CB98B890063FFD1 /* BuildingSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingSectionHeader.swift; sourceTree = "<group>"; };
+		8969F30A2CB98B890063FFD1 /* MenuTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTableView.swift; sourceTree = "<group>"; };
+		8969F30C2CB98B890063FFD1 /* BuildingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingProtocol.swift; sourceTree = "<group>"; };
+		8969F30F2CB98B890063FFD1 /* ScannerDuplicate.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScannerDuplicate.ahap; sourceTree = "<group>"; };
+		8969F3102CB98B890063FFD1 /* ScannerError.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScannerError.ahap; sourceTree = "<group>"; };
+		8969F3112CB98B890063FFD1 /* ScannerInvalid.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScannerInvalid.ahap; sourceTree = "<group>"; };
+		8969F3122CB98B890063FFD1 /* ScannerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerState.swift; sourceTree = "<group>"; };
+		8969F3132CB98B890063FFD1 /* ScannerValid.ahap */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScannerValid.ahap; sourceTree = "<group>"; };
+		8969F3142CB98B890063FFD1 /* ScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerView.swift; sourceTree = "<group>"; };
+		8969F3152CB98B890063FFD1 /* ScannerViewfinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerViewfinder.swift; sourceTree = "<group>"; };
+		8969F3162CB98B890063FFD1 /* ScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerViewModel.swift; sourceTree = "<group>"; };
+		8969F3182CB98B890063FFD1 /* TicketingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingAPI.swift; sourceTree = "<group>"; };
+		8969F31A2CB98B890063FFD1 /* ContactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCell.swift; sourceTree = "<group>"; };
+		8969F31B2CB98B890063FFD1 /* ContactManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactManager.swift; sourceTree = "<group>"; };
+		8969F31C2CB98B890063FFD1 /* ContactsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsTableViewController.swift; sourceTree = "<group>"; };
+		8969F31D2CB98B890063FFD1 /* SupportItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SupportItem.h; sourceTree = "<group>"; };
+		8969F31E2CB98B890063FFD1 /* SupportItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SupportItem.m; sourceTree = "<group>"; };
+		8969F3202CB98B890063FFD1 /* CourseAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertController.swift; sourceTree = "<group>"; };
+		8969F3212CB98B890063FFD1 /* CourseAlertCreateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertCreateController.swift; sourceTree = "<group>"; };
+		8969F3222CB98B890063FFD1 /* CourseAlertSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertSettingsController.swift; sourceTree = "<group>"; };
+		8969F3242CB98B890063FFD1 /* CourseAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlert.swift; sourceTree = "<group>"; };
+		8969F3252CB98B890063FFD1 /* CourseAlertSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertSettings.swift; sourceTree = "<group>"; };
+		8969F3262CB98B890063FFD1 /* CourseAlertSettingsOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertSettingsOptions.swift; sourceTree = "<group>"; };
+		8969F3272CB98B890063FFD1 /* CourseSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSection.swift; sourceTree = "<group>"; };
+		8969F3292CB98B890063FFD1 /* CourseAlertNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertNetworkManager.swift; sourceTree = "<group>"; };
+		8969F32B2CB98B890063FFD1 /* CourseAlertCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertCell.swift; sourceTree = "<group>"; };
+		8969F32C2CB98B890063FFD1 /* CourseAlertCreateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertCreateCell.swift; sourceTree = "<group>"; };
+		8969F32D2CB98B890063FFD1 /* CourseAlertSettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAlertSettingsCell.swift; sourceTree = "<group>"; };
+		8969F32E2CB98B890063FFD1 /* SearchResultsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsCell.swift; sourceTree = "<group>"; };
+		8969F32F2CB98B890063FFD1 /* ZeroCourseAlertsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZeroCourseAlertsCell.swift; sourceTree = "<group>"; };
+		8969F3322CB98B890063FFD1 /* CoursesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesViewModel.swift; sourceTree = "<group>"; };
+		8969F3342CB98B890063FFD1 /* CoursesDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesDayView.swift; sourceTree = "<group>"; };
+		8969F3352CB98B890063FFD1 /* CoursesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesView.swift; sourceTree = "<group>"; };
+		8969F3362CB98B890063FFD1 /* CoursesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesViewController.swift; sourceTree = "<group>"; };
+		8969F3392CB98B890063FFD1 /* DiningLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningLoginController.swift; sourceTree = "<group>"; };
+		8969F33B2CB98B890063FFD1 /* CardHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardHeaderView.swift; sourceTree = "<group>"; };
+		8969F33C2CB98B890063FFD1 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		8969F33E2CB98B890063FFD1 /* DiningAnalyticsGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsGraph.swift; sourceTree = "<group>"; };
+		8969F33F2CB98B890063FFD1 /* DiningAnalyticsGraphBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsGraphBox.swift; sourceTree = "<group>"; };
+		8969F3402CB98B890063FFD1 /* PredictionsGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionsGraphView.swift; sourceTree = "<group>"; };
+		8969F3412CB98B890063FFD1 /* PredictionsGraphView+AxisLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PredictionsGraphView+AxisLabels.swift"; sourceTree = "<group>"; };
+		8969F3422CB98B890063FFD1 /* PredictionsGraphView+SmoothedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PredictionsGraphView+SmoothedData.swift"; sourceTree = "<group>"; };
+		8969F3432CB98B890063FFD1 /* VariableStepLineGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableStepLineGraphView.swift; sourceTree = "<group>"; };
+		8969F3442CB98B890063FFD1 /* VariableStepLineGraphView+GraphEndpointPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VariableStepLineGraphView+GraphEndpointPath.swift"; sourceTree = "<group>"; };
+		8969F3452CB98B890063FFD1 /* VariableStepLineGraphView+PredictionSlopePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VariableStepLineGraphView+PredictionSlopePath.swift"; sourceTree = "<group>"; };
+		8969F3462CB98B890063FFD1 /* VariableStepLineGraphView+VariableStepGraphPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VariableStepLineGraphView+VariableStepGraphPath.swift"; sourceTree = "<group>"; };
+		8969F3482CB98B890063FFD1 /* AnalyticsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCardView.swift; sourceTree = "<group>"; };
+		8969F3492CB98B890063FFD1 /* DiningBalanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningBalanceView.swift; sourceTree = "<group>"; };
+		8969F34B2CB98B890063FFD1 /* DiningVenueDetailHoursView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenueDetailHoursView.swift; sourceTree = "<group>"; };
+		8969F34C2CB98B890063FFD1 /* DiningVenueDetailLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenueDetailLocationView.swift; sourceTree = "<group>"; };
+		8969F34D2CB98B890063FFD1 /* DiningVenueDetailMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenueDetailMenuView.swift; sourceTree = "<group>"; };
+		8969F34E2CB98B890063FFD1 /* DiningVenueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenueDetailView.swift; sourceTree = "<group>"; };
+		8969F34F2CB98B890063FFD1 /* MenuDisclosureGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuDisclosureGroup.swift; sourceTree = "<group>"; };
+		8969F3502CB98B890063FFD1 /* mock_menu.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mock_menu.json; sourceTree = "<group>"; };
+		8969F3522CB98B890063FFD1 /* DiningVenueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningVenueView.swift; sourceTree = "<group>"; };
+		8969F3532CB98B890063FFD1 /* sample-dining-venue.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "sample-dining-venue.json"; sourceTree = "<group>"; };
+		8969F3552CB98B890063FFD1 /* DiningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningView.swift; sourceTree = "<group>"; };
+		8969F3562CB98B890063FFD1 /* DiningViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningViewHeader.swift; sourceTree = "<group>"; };
+		8969F3582CB98B890063FFD1 /* DiningAnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsView.swift; sourceTree = "<group>"; };
+		8969F3592CB98B890063FFD1 /* DiningLoginNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningLoginNavigationView.swift; sourceTree = "<group>"; };
+		8969F35A2CB98B890063FFD1 /* DiningLoginViewSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningLoginViewSwiftUI.swift; sourceTree = "<group>"; };
+		8969F35B2CB98B890063FFD1 /* DiningSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningSettingsView.swift; sourceTree = "<group>"; };
+		8969F35C2CB98B890063FFD1 /* DiningViewControllerSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningViewControllerSwiftUI.swift; sourceTree = "<group>"; };
+		8969F35D2CB98B890063FFD1 /* DiningViewModelSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningViewModelSwiftUI.swift; sourceTree = "<group>"; };
+		8969F35F2CB98B890063FFD1 /* DiningCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningCell.swift; sourceTree = "<group>"; };
+		8969F3622CB98B890063FFD1 /* EventsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsAPI.swift; sourceTree = "<group>"; };
+		8969F3632CB98B890063FFD1 /* PennEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennEvents.swift; sourceTree = "<group>"; };
+		8969F3642CB98B890063FFD1 /* PennEventsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennEventsTableViewCell.swift; sourceTree = "<group>"; };
+		8969F3652CB98B890063FFD1 /* PennEventsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennEventsTableViewController.swift; sourceTree = "<group>"; };
+		8969F3672CB98B890063FFD1 /* FitnessRoomRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessRoomRow.swift; sourceTree = "<group>"; };
+		8969F3682CB98B890063FFD1 /* FitnessSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessSettingsView.swift; sourceTree = "<group>"; };
+		8969F3692CB98B890063FFD1 /* FitnessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessView.swift; sourceTree = "<group>"; };
+		8969F36A2CB98B890063FFD1 /* FitnessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessViewController.swift; sourceTree = "<group>"; };
+		8969F36C2CB98B890063FFD1 /* AnnouncementHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementHeaderView.swift; sourceTree = "<group>"; };
+		8969F36D2CB98B890063FFD1 /* GenericControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericControllers.swift; sourceTree = "<group>"; };
+		8969F36E2CB98B890063FFD1 /* MoveableTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveableTableViewController.swift; sourceTree = "<group>"; };
+		8969F3702CB98B890063FFD1 /* ModularTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModularTableView.swift; sourceTree = "<group>"; };
+		8969F3712CB98B890063FFD1 /* ModularTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModularTableViewCell.swift; sourceTree = "<group>"; };
+		8969F3722CB98B890063FFD1 /* ModularTableViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModularTableViewItem.swift; sourceTree = "<group>"; };
+		8969F3732CB98B890063FFD1 /* ModularTableViewItemTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModularTableViewItemTypes.swift; sourceTree = "<group>"; };
+		8969F3742CB98B890063FFD1 /* ModularTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModularTableViewModel.swift; sourceTree = "<group>"; };
+		8969F3762CB98B890063FFD1 /* FeedAnalyticsEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAnalyticsEngine.swift; sourceTree = "<group>"; };
+		8969F3772CB98B890063FFD1 /* FirebaseAnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsManager.swift; sourceTree = "<group>"; };
+		8969F3782CB98B890063FFD1 /* ImageNetworkingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetworkingManager.swift; sourceTree = "<group>"; };
+		8969F3792CB98B890063FFD1 /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		8969F37A2CB98B890063FFD1 /* UserDBManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDBManager.swift; sourceTree = "<group>"; };
+		8969F37C2CB98B890063FFD1 /* AlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModifier.swift; sourceTree = "<group>"; };
+		8969F37D2CB98B890063FFD1 /* BetaBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaBadge.swift; sourceTree = "<group>"; };
+		8969F37E2CB98B890063FFD1 /* CustomPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPopupView.swift; sourceTree = "<group>"; };
+		8969F37F2CB98B890063FFD1 /* FadingScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadingScrollView.swift; sourceTree = "<group>"; };
+		8969F3802CB98B890063FFD1 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
+		8969F3812CB98B890063FFD1 /* UIKit Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIKit Views.swift"; sourceTree = "<group>"; };
+		8969F3832CB98B890063FFD1 /* KeychainAccessible+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeychainAccessible+Extensions.swift"; sourceTree = "<group>"; };
+		8969F3842CB98B890063FFD1 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
+		8969F3852CB98B890063FFD1 /* UserDefaults + Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults + Helpers.swift"; sourceTree = "<group>"; };
+		8969F3872CB98B890063FFD1 /* GSRGroupConfirmBookingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupConfirmBookingController.swift; sourceTree = "<group>"; };
+		8969F3882CB98B890063FFD1 /* GSRGroupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupController.swift; sourceTree = "<group>"; };
+		8969F3892CB98B890063FFD1 /* GSRGroupInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupInviteViewController.swift; sourceTree = "<group>"; };
+		8969F38A2CB98B890063FFD1 /* GSRGroupNewIntialController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupNewIntialController.swift; sourceTree = "<group>"; };
+		8969F38B2CB98B890063FFD1 /* GSRManageGroupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRManageGroupController.swift; sourceTree = "<group>"; };
+		8969F38D2CB98B890063FFD1 /* GSRBookable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRBookable.swift; sourceTree = "<group>"; };
+		8969F38E2CB98B890063FFD1 /* GSRController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRController.swift; sourceTree = "<group>"; };
+		8969F38F2CB98B890063FFD1 /* GSRDeletable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRDeletable.swift; sourceTree = "<group>"; };
+		8969F3902CB98B890063FFD1 /* GSRLocationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRLocationsController.swift; sourceTree = "<group>"; };
+		8969F3912CB98B890063FFD1 /* GSRReservationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRReservationsController.swift; sourceTree = "<group>"; };
+		8969F3922CB98B890063FFD1 /* GSRTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRTabController.swift; sourceTree = "<group>"; };
+		8969F3942CB98B890063FFD1 /* GSRAPIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRAPIResponse.swift; sourceTree = "<group>"; };
+		8969F3952CB98B890063FFD1 /* GSRBooking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRBooking.swift; sourceTree = "<group>"; };
+		8969F3962CB98B890063FFD1 /* GSRDateHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRDateHandler.swift; sourceTree = "<group>"; };
+		8969F3972CB98B890063FFD1 /* GSRGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroup.swift; sourceTree = "<group>"; };
+		8969F3982CB98B890063FFD1 /* GSRGroupUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupUser.swift; sourceTree = "<group>"; };
+		8969F3992CB98B890063FFD1 /* GSRLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRLocation.swift; sourceTree = "<group>"; };
+		8969F39A2CB98B890063FFD1 /* GSRLocationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRLocationModel.swift; sourceTree = "<group>"; };
+		8969F39B2CB98B890063FFD1 /* GSRReservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRReservation.swift; sourceTree = "<group>"; };
+		8969F39C2CB98B890063FFD1 /* GSRRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRRoom.swift; sourceTree = "<group>"; };
+		8969F39D2CB98B890063FFD1 /* GSRTimeSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRTimeSlot.swift; sourceTree = "<group>"; };
+		8969F39F2CB98B890063FFD1 /* GSRGroupNetworkManager..swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupNetworkManager..swift; sourceTree = "<group>"; };
+		8969F3A02CB98B890063FFD1 /* GSRNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRNetworkManager.swift; sourceTree = "<group>"; };
+		8969F3A22CB98B890063FFD1 /* GSRManageGroupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRManageGroupViewModel.swift; sourceTree = "<group>"; };
+		8969F3A32CB98B890063FFD1 /* GSRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRViewModel.swift; sourceTree = "<group>"; };
+		8969F3A52CB98B890063FFD1 /* CreateGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateGroupCell.swift; sourceTree = "<group>"; };
+		8969F3A62CB98B890063FFD1 /* GroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCell.swift; sourceTree = "<group>"; };
+		8969F3A72CB98B890063FFD1 /* GroupHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupHeaderCell.swift; sourceTree = "<group>"; };
+		8969F3A82CB98B890063FFD1 /* GroupIndividualSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupIndividualSettingView.swift; sourceTree = "<group>"; };
+		8969F3A92CB98B890063FFD1 /* GroupInviteUserCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupInviteUserCell.swift; sourceTree = "<group>"; };
+		8969F3AA2CB98B890063FFD1 /* GroupManageButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupManageButtonCell.swift; sourceTree = "<group>"; };
+		8969F3AB2CB98B890063FFD1 /* GroupMemberCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupMemberCell.swift; sourceTree = "<group>"; };
+		8969F3AC2CB98B890063FFD1 /* GroupSettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSettingsCell.swift; sourceTree = "<group>"; };
+		8969F3AD2CB98B890063FFD1 /* GSRColorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRColorCell.swift; sourceTree = "<group>"; };
+		8969F3AE2CB98B890063FFD1 /* GSRGroupIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupIconView.swift; sourceTree = "<group>"; };
+		8969F3B02CB98B890063FFD1 /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
+		8969F3B12CB98B890063FFD1 /* GSRClosedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRClosedView.swift; sourceTree = "<group>"; };
+		8969F3B22CB98B890063FFD1 /* GSRLocationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRLocationCell.swift; sourceTree = "<group>"; };
+		8969F3B32CB98B890063FFD1 /* GSRRangeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRRangeSlider.swift; sourceTree = "<group>"; };
+		8969F3B42CB98B890063FFD1 /* GSRTimeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRTimeCell.swift; sourceTree = "<group>"; };
+		8969F3B52CB98B890063FFD1 /* NoReservationsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoReservationsCell.swift; sourceTree = "<group>"; };
+		8969F3B62CB98B890063FFD1 /* ReservationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationCell.swift; sourceTree = "<group>"; };
+		8969F3B72CB98B890063FFD1 /* RoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCell.swift; sourceTree = "<group>"; };
+		8969F3B92CB98B890063FFD1 /* RangeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSlider.swift; sourceTree = "<group>"; };
+		8969F3BA2CB98B890063FFD1 /* TextLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLayer.swift; sourceTree = "<group>"; };
+		8969F3BB2CB98B890063FFD1 /* ThumbLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbLayer.swift; sourceTree = "<group>"; };
+		8969F3BC2CB98B890063FFD1 /* TrackLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackLayer.swift; sourceTree = "<group>"; };
+		8969F3BF2CB98B890063FFD1 /* CalendarAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAPI.swift; sourceTree = "<group>"; };
+		8969F3C02CB98B890063FFD1 /* CalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEvent.swift; sourceTree = "<group>"; };
+		8969F3C12CB98B890063FFD1 /* HomeCalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarCell.swift; sourceTree = "<group>"; };
+		8969F3C22CB98B890063FFD1 /* HomeCalendarCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarCellItem.swift; sourceTree = "<group>"; };
+		8969F3C32CB98B890063FFD1 /* UniversityNotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversityNotificationCell.swift; sourceTree = "<group>"; };
+		8969F3C52CB98B890063FFD1 /* HomeDiningCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDiningCell.swift; sourceTree = "<group>"; };
+		8969F3C62CB98B890063FFD1 /* HomeDiningCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDiningCellItem.swift; sourceTree = "<group>"; };
+		8969F3C82CB98B890063FFD1 /* FeatureAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureAnnouncement.swift; sourceTree = "<group>"; };
+		8969F3C92CB98B890063FFD1 /* HomeFeatureCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFeatureCell.swift; sourceTree = "<group>"; };
+		8969F3CA2CB98B890063FFD1 /* HomeFeatureCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFeatureCellItem.swift; sourceTree = "<group>"; };
+		8969F3CC2CB98B890063FFD1 /* GSRGroupInviteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSRGroupInviteCell.swift; sourceTree = "<group>"; };
+		8969F3CD2CB98B890063FFD1 /* HomeGroupInvitesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGroupInvitesCell.swift; sourceTree = "<group>"; };
+		8969F3CE2CB98B890063FFD1 /* HomeGroupInvitesCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGroupInvitesCellItem.swift; sourceTree = "<group>"; };
+		8969F3D02CB98B890063FFD1 /* BookingRowCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingRowCell.swift; sourceTree = "<group>"; };
+		8969F3D22CB98B890063FFD1 /* HomeGSRBookingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGSRBookingButton.swift; sourceTree = "<group>"; };
+		8969F3D32CB98B890063FFD1 /* HomeGSRCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGSRCellItem.swift; sourceTree = "<group>"; };
+		8969F3D42CB98B890063FFD1 /* HomeStudyRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStudyRoomCell.swift; sourceTree = "<group>"; };
+		8969F3D62CB98B890063FFD1 /* HomeGSRLocationsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGSRLocationsCell.swift; sourceTree = "<group>"; };
+		8969F3D72CB98B890063FFD1 /* HomeGSRLocationsCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGSRLocationsCellItem.swift; sourceTree = "<group>"; };
+		8969F3D92CB98B890063FFD1 /* HomeReservationsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeReservationsCell.swift; sourceTree = "<group>"; };
+		8969F3DA2CB98B890063FFD1 /* HomeReservationsCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeReservationsCellItem.swift; sourceTree = "<group>"; };
+		8969F3DC2CB98B890063FFD1 /* HomeLaundryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLaundryCell.swift; sourceTree = "<group>"; };
+		8969F3DD2CB98B890063FFD1 /* HomeLaundryCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLaundryCellItem.swift; sourceTree = "<group>"; };
+		8969F3DF2CB98B890063FFD1 /* HomeNewsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNewsCell.swift; sourceTree = "<group>"; };
+		8969F3E02CB98B890063FFD1 /* HomeNewsCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNewsCellItem.swift; sourceTree = "<group>"; };
+		8969F3E12CB98B890063FFD1 /* NativeNewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNewsViewController.swift; sourceTree = "<group>"; };
+		8969F3E22CB98B890063FFD1 /* NewsArticle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsArticle.swift; sourceTree = "<group>"; };
+		8969F3E42CB98B890063FFD1 /* HomePollsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePollsCell.swift; sourceTree = "<group>"; };
+		8969F3E52CB98B890063FFD1 /* HomePollsCellFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePollsCellFooter.swift; sourceTree = "<group>"; };
+		8969F3E62CB98B890063FFD1 /* HomePollsCellHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePollsCellHeader.swift; sourceTree = "<group>"; };
+		8969F3E72CB98B890063FFD1 /* HomePollsCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePollsCellItem.swift; sourceTree = "<group>"; };
+		8969F3E82CB98B890063FFD1 /* PollOptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollOptionCell.swift; sourceTree = "<group>"; };
+		8969F3EA2CB98B890063FFD1 /* HomePostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePostCell.swift; sourceTree = "<group>"; };
+		8969F3EB2CB98B890063FFD1 /* HomePostCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePostCellItem.swift; sourceTree = "<group>"; };
+		8969F3EC2CB98B890063FFD1 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
+		8969F3EE2CB98B890063FFD1 /* HomeFlingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlingCell.swift; sourceTree = "<group>"; };
+		8969F3EF2CB98B890063FFD1 /* HomeFlingCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlingCellItem.swift; sourceTree = "<group>"; };
+		8969F3F12CB98B890063FFD1 /* HomeUpdateCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUpdateCellItem.swift; sourceTree = "<group>"; };
+		8969F3F32CB98B890063FFD1 /* HomeCellConformable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellConformable.swift; sourceTree = "<group>"; };
+		8969F3F42CB98B890063FFD1 /* HomeCellHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellHeader.swift; sourceTree = "<group>"; };
+		8969F3F52CB98B890063FFD1 /* HomeCellProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellProtocols.swift; sourceTree = "<group>"; };
+		8969F3F62CB98B890063FFD1 /* HomeCellSafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellSafeArea.swift; sourceTree = "<group>"; };
+		8969F3F82CB98B890063FFD1 /* BuildingMapWebviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingMapWebviewController.swift; sourceTree = "<group>"; };
+		8969F3F92CB98B890063FFD1 /* DiningCellSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningCellSettingsController.swift; sourceTree = "<group>"; };
+		8969F3FA2CB98B890063FFD1 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		8969F3FB2CB98B890063FFD1 /* HomeViewController + Delegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeViewController + Delegates.swift"; sourceTree = "<group>"; };
+		8969F3FD2CB98B890063FFD1 /* HomeCellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellItem.swift; sourceTree = "<group>"; };
+		8969F3FE2CB98B890063FFD1 /* HomeItemTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeItemTypes.swift; sourceTree = "<group>"; };
+		8969F3FF2CB98B890063FFD1 /* HomeTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTableViewModel.swift; sourceTree = "<group>"; };
+		8969F4012CB98B890063FFD1 /* HomeAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPIService.swift; sourceTree = "<group>"; };
+		8969F4032CB98B890063FFD1 /* CalendarCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCardView.swift; sourceTree = "<group>"; };
+		8969F4042CB98B890063FFD1 /* HomeCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCardView.swift; sourceTree = "<group>"; };
+		8969F4052CB98B890063FFD1 /* HomeSublettingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSublettingBanner.swift; sourceTree = "<group>"; };
+		8969F4062CB98B890063FFD1 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		8969F4072CB98B890063FFD1 /* HomeViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewData.swift; sourceTree = "<group>"; };
+		8969F4082CB98B890063FFD1 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		8969F40A2CB98B890063FFD1 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
+		8969F40C2CB98B890063FFD1 /* AddLaundryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLaundryCell.swift; sourceTree = "<group>"; };
+		8969F40D2CB98B890063FFD1 /* LaundryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryCell.swift; sourceTree = "<group>"; };
+		8969F40E2CB98B890063FFD1 /* LaundryCell + Graph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LaundryCell + Graph.swift"; sourceTree = "<group>"; };
+		8969F40F2CB98B890063FFD1 /* LaundryGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryGraphView.swift; sourceTree = "<group>"; };
+		8969F4102CB98B890063FFD1 /* LaundryMachineCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryMachineCell.swift; sourceTree = "<group>"; };
+		8969F4112CB98B890063FFD1 /* LaundryMachinesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryMachinesView.swift; sourceTree = "<group>"; };
+		8969F4132CB98B890063FFD1 /* LaundryMachineCellTappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryMachineCellTappable.swift; sourceTree = "<group>"; };
+		8969F4142CB98B890063FFD1 /* LaundryTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryTableViewController.swift; sourceTree = "<group>"; };
+		8969F4152CB98B890063FFD1 /* RoomSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSelectionViewController.swift; sourceTree = "<group>"; };
+		8969F4172CB98B890063FFD1 /* LaundryNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryNotificationCenter.swift; sourceTree = "<group>"; };
+		8969F4182CB98B890063FFD1 /* LaundryRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryRoom.swift; sourceTree = "<group>"; };
+		8969F41A2CB98B890063FFD1 /* LaundryAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryAPIService.swift; sourceTree = "<group>"; };
+		8969F41C2CB98B890063FFD1 /* RoomSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSelectionView.swift; sourceTree = "<group>"; };
+		8969F41F2CB98B890063FFD1 /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
+		8969F4202CB98B890063FFD1 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		8969F4212CB98B890063FFD1 /* CampusExpressLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampusExpressLoginController.swift; sourceTree = "<group>"; };
+		8969F4222CB98B890063FFD1 /* CampusExpressNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampusExpressNetworkManager.swift; sourceTree = "<group>"; };
+		8969F4232CB98B890063FFD1 /* Degree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Degree.swift; sourceTree = "<group>"; };
+		8969F4242CB98B890063FFD1 /* LabsLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabsLoginController.swift; sourceTree = "<group>"; };
+		8969F4252CB98B890063FFD1 /* LabsLoginSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabsLoginSwiftUI.swift; sourceTree = "<group>"; };
+		8969F4262CB98B890063FFD1 /* LoggedOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutView.swift; sourceTree = "<group>"; };
+		8969F4272CB98B890063FFD1 /* PathAtPennNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathAtPennNetworkManager.swift; sourceTree = "<group>"; };
+		8969F4282CB98B890063FFD1 /* PennCashNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennCashNetworkManager.swift; sourceTree = "<group>"; };
+		8969F4292CB98B890063FFD1 /* PennInTouchNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennInTouchNetworkManager.swift; sourceTree = "<group>"; };
+		8969F42B2CB98B890063FFD1 /* AddressMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressMapView.swift; sourceTree = "<group>"; };
+		8969F42C2CB98B890063FFD1 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
+		8969F42D2CB98B890063FFD1 /* PennCoordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennCoordinate.swift; sourceTree = "<group>"; };
+		8969F42F2CB98B890063FFD1 /* PacCodeNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacCodeNetworkManager.swift; sourceTree = "<group>"; };
+		8969F4302CB98B890063FFD1 /* PacCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacCodeViewController.swift; sourceTree = "<group>"; };
+		8969F4322CB98B890063FFD1 /* ProfilePageNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePageNetworkManager.swift; sourceTree = "<group>"; };
+		8969F4342CB98B890063FFD1 /* InfoTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableViewController.swift; sourceTree = "<group>"; };
+		8969F4352CB98B890063FFD1 /* InfoTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableViewModel.swift; sourceTree = "<group>"; };
+		8969F4362CB98B890063FFD1 /* ProfilePageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePageTableViewCell.swift; sourceTree = "<group>"; };
+		8969F4372CB98B890063FFD1 /* ProfilePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePageViewController.swift; sourceTree = "<group>"; };
+		8969F4382CB98B890063FFD1 /* ProfilePageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePageViewModel.swift; sourceTree = "<group>"; };
+		8969F4392CB98B890063FFD1 /* ProfilePictureTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePictureTableViewCell.swift; sourceTree = "<group>"; };
+		8969F43B2CB98B890063FFD1 /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
+		8969F43C2CB98B890063FFD1 /* HeaderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewCell.swift; sourceTree = "<group>"; };
+		8969F43D2CB98B890063FFD1 /* MoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreCell.swift; sourceTree = "<group>"; };
+		8969F43E2CB98B890063FFD1 /* MoreHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreHeaderView.swift; sourceTree = "<group>"; };
+		8969F43F2CB98B890063FFD1 /* MoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreView.swift; sourceTree = "<group>"; };
+		8969F4402CB98B890063FFD1 /* MoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreViewController.swift; sourceTree = "<group>"; };
+		8969F4412CB98B890063FFD1 /* ProfileRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRowView.swift; sourceTree = "<group>"; };
+		8969F4432CB98B890063FFD1 /* NewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsViewController.swift; sourceTree = "<group>"; };
+		8969F4452CB98B890063FFD1 /* NotificationAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAPIModel.swift; sourceTree = "<group>"; };
+		8969F4462CB98B890063FFD1 /* NotificationsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSetting.swift; sourceTree = "<group>"; };
+		8969F4482CB98B890063FFD1 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+		8969F4492CB98B890063FFD1 /* NotificationsViewControllerSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsViewControllerSwiftUI.swift; sourceTree = "<group>"; };
+		8969F44A2CB98B890063FFD1 /* NotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewModel.swift; sourceTree = "<group>"; };
+		8969F44C2CB98B890063FFD1 /* NotificationPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreference.swift; sourceTree = "<group>"; };
+		8969F44D2CB98B890063FFD1 /* NotificationRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRequestable.swift; sourceTree = "<group>"; };
+		8969F44E2CB98B890063FFD1 /* NotificationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTableViewCell.swift; sourceTree = "<group>"; };
+		8969F44F2CB98B890063FFD1 /* NotificationsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTableViewController.swift; sourceTree = "<group>"; };
+		8969F4512CB98B890063FFD1 /* OnboardingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingController.swift; sourceTree = "<group>"; };
+		8969F4522CB98B890063FFD1 /* Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
+		8969F4532CB98B890063FFD1 /* PageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageCell.swift; sourceTree = "<group>"; };
+		8969F4542CB98B890063FFD1 /* SAConfettiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SAConfettiView.swift; sourceTree = "<group>"; };
+		8969F4552CB98B890063FFD1 /* SelectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionCell.swift; sourceTree = "<group>"; };
+		8969F4572CB98B890063FFD1 /* AIChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatModel.swift; sourceTree = "<group>"; };
+		8969F4582CB98B890063FFD1 /* AIChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatView.swift; sourceTree = "<group>"; };
+		8969F4592CB98B890063FFD1 /* AIChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModel.swift; sourceTree = "<group>"; };
+		8969F45A2CB98B890063FFD1 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
+		8969F45B2CB98B890063FFD1 /* ChatMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageView.swift; sourceTree = "<group>"; };
+		8969F45D2CB98B890063FFD1 /* PollQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollQuestion.swift; sourceTree = "<group>"; };
+		8969F45F2CB98B890063FFD1 /* PollsNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsNetworkManager.swift; sourceTree = "<group>"; };
+		8969F4612CB98B890063FFD1 /* PollsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsView.swift; sourceTree = "<group>"; };
+		8969F4622CB98B890063FFD1 /* PollsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsViewController.swift; sourceTree = "<group>"; };
+		8969F4632CB98B890063FFD1 /* PollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollView.swift; sourceTree = "<group>"; };
+		8969F4652CB98B890063FFD1 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
+		8969F4662CB98B890063FFD1 /* PreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
+		8969F4682CB98B890063FFD1 /* PermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionView.swift; sourceTree = "<group>"; };
+		8969F4692CB98B890063FFD1 /* PrivacyPermissionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionDelegate.swift; sourceTree = "<group>"; };
+		8969F46A2CB98B890063FFD1 /* PrivacyPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPreference.swift; sourceTree = "<group>"; };
+		8969F46B2CB98B890063FFD1 /* PrivacyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyTableViewCell.swift; sourceTree = "<group>"; };
+		8969F46C2CB98B890063FFD1 /* PrivacyTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyTableViewController.swift; sourceTree = "<group>"; };
+		8969F46E2CB98B890063FFD1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8969F46F2CB98B890063FFD1 /* AppDelegate+NotificationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+NotificationExtension.swift"; sourceTree = "<group>"; };
+		8969F4702CB98B890063FFD1 /* ControllerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControllerModel.swift; sourceTree = "<group>"; };
+		8969F4712CB98B890063FFD1 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		8969F4722CB98B890063FFD1 /* Features.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features.swift; sourceTree = "<group>"; };
+		8969F4732CB98B890063FFD1 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		8969F4742CB98B890063FFD1 /* PennMobile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PennMobile.swift; sourceTree = "<group>"; };
+		8969F4752CB98B890063FFD1 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		8969F4762CB98B890063FFD1 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
+		8969F4772CB98B890063FFD1 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
+		8969F4782CB98B890063FFD1 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		8969F4792CB98B890063FFD1 /* Toasts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toasts.swift; sourceTree = "<group>"; };
+		8969F47B2CB98B890063FFD1 /* MyListingsActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyListingsActivity.swift; sourceTree = "<group>"; };
+		8969F47C2CB98B890063FFD1 /* NewListingForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewListingForm.swift; sourceTree = "<group>"; };
+		8969F47E2CB98B890063FFD1 /* MarketplaceFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceFilterView.swift; sourceTree = "<group>"; };
+		8969F47F2CB98B890063FFD1 /* MarketplaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceView.swift; sourceTree = "<group>"; };
+		8969F4802CB98B890063FFD1 /* SubletCandidatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubletCandidatesView.swift; sourceTree = "<group>"; };
+		8969F4812CB98B890063FFD1 /* SubletDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubletDetailView.swift; sourceTree = "<group>"; };
+		8969F4822CB98B890063FFD1 /* SubletDisplayRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubletDisplayRow.swift; sourceTree = "<group>"; };
+		8969F4832CB98B890063FFD1 /* SubletInterestForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubletInterestForm.swift; sourceTree = "<group>"; };
+		8969F4842CB98B890063FFD1 /* SubletMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubletMapView.swift; sourceTree = "<group>"; };
+		8969F4852CB98B890063FFD1 /* SublettingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SublettingAPI.swift; sourceTree = "<group>"; };
+		8969F4862CB98B890063FFD1 /* SublettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SublettingViewModel.swift; sourceTree = "<group>"; };
+		8969F4882CB98B890063FFD1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		8969F4892CB98B890063FFD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8969F48A2CB98B890063FFD1 /* PennMobile-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PennMobile-Bridging-Header.h"; sourceTree = "<group>"; };
+		8969F48B2CB98B890063FFD1 /* PrefixHeader.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefixHeader.pch; sourceTree = "<group>"; };
+		8969F48D2CB98B890063FFD1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		8969F48E2CB98B890063FFD1 /* PennMobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PennMobile.entitlements; sourceTree = "<group>"; };
+		8969F5C82CB98B8B0063FFD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8969F5C92CB98B8B0063FFD1 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		8969F5CA2CB98B8B0063FFD1 /* NotificationService+ImageCacheing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationService+ImageCacheing.swift"; sourceTree = "<group>"; };
+		8969F5CC2CB98B900063FFD1 /* CoursesDayWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesDayWidget.swift; sourceTree = "<group>"; };
+		8969F5CD2CB98B900063FFD1 /* CoursesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesProvider.swift; sourceTree = "<group>"; };
+		8969F5CF2CB98B900063FFD1 /* DiningAnalyticsHomeWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsHomeWidget.swift; sourceTree = "<group>"; };
+		8969F5D02CB98B900063FFD1 /* DiningAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningAnalyticsProvider.swift; sourceTree = "<group>"; };
+		8969F5D22CB98B900063FFD1 /* DiningHoursProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningHoursProvider.swift; sourceTree = "<group>"; };
+		8969F5D32CB98B900063FFD1 /* DiningHoursWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningHoursWidget.swift; sourceTree = "<group>"; };
+		8969F5D52CB98B900063FFD1 /* FitnessProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessProvider.swift; sourceTree = "<group>"; };
+		8969F5D62CB98B900063FFD1 /* FitnessWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitnessWidget.swift; sourceTree = "<group>"; };
+		8969F5D82CB98B900063FFD1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		8969F5D92CB98B900063FFD1 /* ConfigurationRepresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationRepresenting.swift; sourceTree = "<group>"; };
+		8969F5DA2CB98B900063FFD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8969F5DB2CB98B900063FFD1 /* LaundryLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaundryLiveActivity.swift; sourceTree = "<group>"; };
+		8969F5DC2CB98B900063FFD1 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
+		8969F5DD2CB98B900063FFD1 /* WidgetBackgroundTypeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackgroundTypeExtensions.swift; sourceTree = "<group>"; };
+		8969F5DE2CB98B900063FFD1 /* WidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBundle.swift; sourceTree = "<group>"; };
+		8969F5DF2CB98B900063FFD1 /* WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WidgetExtension.entitlements; sourceTree = "<group>"; };
 		89EA262D290F9411008F26CF /* Intents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = Intents.intentdefinition; sourceTree = "<group>"; };
 		B6B1E089214442A200CCBBCD /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = SOURCE_ROOT; };
 		BED8AA4945D67F0ED89FA9B0 /* Pods_PennMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PennMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -122,35 +848,10 @@
 			);
 			target = F230FB0D225809E900760499 /* AutomatedScreenshotUITests */;
 		};
-		892B2D742C9874A800CD769A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			publicHeaders = (
-				PennMobileShared.h,
-			);
-			target = 6E4D82152AC8C91C009AB78E /* PennMobileShared */;
-		};
-		89A703E82C9876F00070DF19 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Supporting_Files/Info.plist,
-			);
-			target = 2166405F1EBADADA00746B8E /* PennMobile */;
-		};
-		89A7FE022C9875470070DF19 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Info.plist,
-			);
-			target = 8932693228FC75A5003D4BF9 /* WidgetExtension */;
-		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		892B2CDC2C98743000CD769A /* AutomatedScreenshotUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (892B2CE02C98743000CD769A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AutomatedScreenshotUITests; sourceTree = "<group>"; };
-		892B2D522C9874A800CD769A /* PennMobileShared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (892B2D742C9874A800CD769A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = PennMobileShared; sourceTree = "<group>"; };
-		89A702AE2C9876F00070DF19 /* PennMobile */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (89A703E82C9876F00070DF19 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = PennMobile; sourceTree = "<group>"; };
-		89A7FDDE2C9875430070DF19 /* NotificationServiceExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NotificationServiceExtension; sourceTree = "<group>"; };
-		89A7FDF22C9875470070DF19 /* Widget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (89A7FE022C9875470070DF19 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Widget; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,10 +907,10 @@
 			isa = PBXGroup;
 			children = (
 				6C392E3727B5BDF20097640B /* Config */,
-				892B2D522C9874A800CD769A /* PennMobileShared */,
-				89A702AE2C9876F00070DF19 /* PennMobile */,
-				89A7FDDE2C9875430070DF19 /* NotificationServiceExtension */,
-				89A7FDF22C9875470070DF19 /* Widget */,
+				8969F2D82CB98B860063FFD1 /* PennMobileShared */,
+				8969F48F2CB98B890063FFD1 /* PennMobile */,
+				8969F5CB2CB98B8B0063FFD1 /* NotificationServiceExtension */,
+				8969F5E02CB98B900063FFD1 /* Widget */,
 				89EA262D290F9411008F26CF /* Intents.intentdefinition */,
 				4273BCFE2BD2D8D80070C1B8 /* PrivacyInfo.xcprivacy */,
 				B6B1E089214442A200CCBBCD /* fastlane */,
@@ -253,6 +954,1210 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		8969F2B12CB98B860063FFD1 /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2AF2CB98B860063FFD1 /* Course.swift */,
+				8969F2B02CB98B860063FFD1 /* ScheduleView.swift */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
+		8969F2B92CB98B860063FFD1 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2B22CB98B860063FFD1 /* DiningBalance.swift */,
+				8969F2B32CB98B860063FFD1 /* DiningMenu.swift */,
+				8969F2B42CB98B860063FFD1 /* DiningPlan.swift */,
+				8969F2B52CB98B860063FFD1 /* DiningToken.swift */,
+				8969F2B62CB98B860063FFD1 /* DiningVenue.swift */,
+				8969F2B72CB98B860063FFD1 /* DiningVenue+Extensions.swift */,
+				8969F2B82CB98B860063FFD1 /* PastDiningBalances.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		8969F2BD2CB98B860063FFD1 /* Dining */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2B92CB98B860063FFD1 /* Models */,
+				8969F2BA2CB98B860063FFD1 /* DiningAnalyticsViewModel.swift */,
+				8969F2BB2CB98B860063FFD1 /* DiningAPI.swift */,
+				8969F2BC2CB98B860063FFD1 /* DiningVenueRow.swift */,
+			);
+			path = Dining;
+			sourceTree = "<group>";
+		};
+		8969F2C12CB98B860063FFD1 /* Fitness */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2BE2CB98B860063FFD1 /* FitnessAPI.swift */,
+				8969F2BF2CB98B860063FFD1 /* FitnessGraph.swift */,
+				8969F2C02CB98B860063FFD1 /* FitnessModel.swift */,
+			);
+			path = Fitness;
+			sourceTree = "<group>";
+		};
+		8969F2CD2CB98B860063FFD1 /* General */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2C22CB98B860063FFD1 /* BadgeView.swift */,
+				8969F2C32CB98B860063FFD1 /* Colors.swift */,
+				8969F2C42CB98B860063FFD1 /* Day.swift */,
+				8969F2C52CB98B860063FFD1 /* Extensions.swift */,
+				8969F2C62CB98B860063FFD1 /* KeychainAccessible.swift */,
+				8969F2C72CB98B860063FFD1 /* MeterView.swift */,
+				8969F2C82CB98B860063FFD1 /* PhoneNumberFormat.swift */,
+				8969F2C92CB98B860063FFD1 /* SearchBar.swift */,
+				8969F2CA2CB98B860063FFD1 /* SecureStore.swift */,
+				8969F2CB2CB98B860063FFD1 /* Storage.swift */,
+				8969F2CC2CB98B860063FFD1 /* WidgetKind.swift */,
+			);
+			path = General;
+			sourceTree = "<group>";
+		};
+		8969F2D02CB98B860063FFD1 /* Laundry */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2CE2CB98B860063FFD1 /* LaundryAttributes.swift */,
+				8969F2CF2CB98B860063FFD1 /* LaundryMachine.swift */,
+			);
+			path = Laundry;
+			sourceTree = "<group>";
+		};
+		8969F2D32CB98B860063FFD1 /* Networking + Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2D12CB98B860063FFD1 /* Multipart.swift */,
+				8969F2D22CB98B860063FFD1 /* NetworkingError.swift */,
+			);
+			path = "Networking + Analytics";
+			sourceTree = "<group>";
+		};
+		8969F2D62CB98B860063FFD1 /* Subletting */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2D42CB98B860063FFD1 /* SubletDisplayBox.swift */,
+				8969F2D52CB98B860063FFD1 /* SublettingModels.swift */,
+			);
+			path = Subletting;
+			sourceTree = "<group>";
+		};
+		8969F2D82CB98B860063FFD1 /* PennMobileShared */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2B12CB98B860063FFD1 /* Courses */,
+				8969F2BD2CB98B860063FFD1 /* Dining */,
+				8969F2C12CB98B860063FFD1 /* Fitness */,
+				8969F2CD2CB98B860063FFD1 /* General */,
+				8969F2D02CB98B860063FFD1 /* Laundry */,
+				8969F2D32CB98B860063FFD1 /* Networking + Analytics */,
+				8969F2D62CB98B860063FFD1 /* Subletting */,
+				8969F2D72CB98B860063FFD1 /* PennMobileShared.h */,
+			);
+			path = PennMobileShared;
+			sourceTree = "<group>";
+		};
+		8969F2FD2CB98B890063FFD1 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2FA2CB98B890063FFD1 /* OAuth2NetworkManager.swift */,
+				8969F2FB2CB98B890063FFD1 /* PennAuthRequestable.swift */,
+				8969F2FC2CB98B890063FFD1 /* PennLoginController.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		8969F3022CB98B890063FFD1 /* Banners */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2FE2CB98B890063FFD1 /* BannerDescription.swift */,
+				8969F2FF2CB98B890063FFD1 /* BannerView.swift */,
+				8969F3002CB98B890063FFD1 /* BannerViewModel.swift */,
+				8969F3012CB98B890063FFD1 /* UserEngagementPopupView.swift */,
+			);
+			path = Banners;
+			sourceTree = "<group>";
+		};
+		8969F30B2CB98B890063FFD1 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3032CB98B890063FFD1 /* BuildingCell.swift */,
+				8969F3042CB98B890063FFD1 /* BuildingFoodMenuCell.swift */,
+				8969F3052CB98B890063FFD1 /* BuildingHeaderCell.swift */,
+				8969F3062CB98B890063FFD1 /* BuildingHoursCell.swift */,
+				8969F3072CB98B890063FFD1 /* BuildingImageCell.swift */,
+				8969F3082CB98B890063FFD1 /* BuildingMapCell.swift */,
+				8969F3092CB98B890063FFD1 /* BuildingSectionHeader.swift */,
+				8969F30A2CB98B890063FFD1 /* MenuTableView.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		8969F30D2CB98B890063FFD1 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				8969F30C2CB98B890063FFD1 /* BuildingProtocol.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		8969F30E2CB98B890063FFD1 /* Buildings */ = {
+			isa = PBXGroup;
+			children = (
+				8969F30B2CB98B890063FFD1 /* Cells */,
+				8969F30D2CB98B890063FFD1 /* Models */,
+			);
+			path = Buildings;
+			sourceTree = "<group>";
+		};
+		8969F3172CB98B890063FFD1 /* Ticket Scanner */ = {
+			isa = PBXGroup;
+			children = (
+				8969F30F2CB98B890063FFD1 /* ScannerDuplicate.ahap */,
+				8969F3102CB98B890063FFD1 /* ScannerError.ahap */,
+				8969F3112CB98B890063FFD1 /* ScannerInvalid.ahap */,
+				8969F3122CB98B890063FFD1 /* ScannerState.swift */,
+				8969F3132CB98B890063FFD1 /* ScannerValid.ahap */,
+				8969F3142CB98B890063FFD1 /* ScannerView.swift */,
+				8969F3152CB98B890063FFD1 /* ScannerViewfinder.swift */,
+				8969F3162CB98B890063FFD1 /* ScannerViewModel.swift */,
+			);
+			path = "Ticket Scanner";
+			sourceTree = "<group>";
+		};
+		8969F3192CB98B890063FFD1 /* Clubs */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3172CB98B890063FFD1 /* Ticket Scanner */,
+				8969F3182CB98B890063FFD1 /* TicketingAPI.swift */,
+			);
+			path = Clubs;
+			sourceTree = "<group>";
+		};
+		8969F31F2CB98B890063FFD1 /* Contacts */ = {
+			isa = PBXGroup;
+			children = (
+				8969F31A2CB98B890063FFD1 /* ContactCell.swift */,
+				8969F31B2CB98B890063FFD1 /* ContactManager.swift */,
+				8969F31C2CB98B890063FFD1 /* ContactsTableViewController.swift */,
+				8969F31D2CB98B890063FFD1 /* SupportItem.h */,
+				8969F31E2CB98B890063FFD1 /* SupportItem.m */,
+			);
+			path = Contacts;
+			sourceTree = "<group>";
+		};
+		8969F3232CB98B890063FFD1 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3202CB98B890063FFD1 /* CourseAlertController.swift */,
+				8969F3212CB98B890063FFD1 /* CourseAlertCreateController.swift */,
+				8969F3222CB98B890063FFD1 /* CourseAlertSettingsController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		8969F3282CB98B890063FFD1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3242CB98B890063FFD1 /* CourseAlert.swift */,
+				8969F3252CB98B890063FFD1 /* CourseAlertSettings.swift */,
+				8969F3262CB98B890063FFD1 /* CourseAlertSettingsOptions.swift */,
+				8969F3272CB98B890063FFD1 /* CourseSection.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8969F32A2CB98B890063FFD1 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3292CB98B890063FFD1 /* CourseAlertNetworkManager.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8969F3302CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F32B2CB98B890063FFD1 /* CourseAlertCell.swift */,
+				8969F32C2CB98B890063FFD1 /* CourseAlertCreateCell.swift */,
+				8969F32D2CB98B890063FFD1 /* CourseAlertSettingsCell.swift */,
+				8969F32E2CB98B890063FFD1 /* SearchResultsCell.swift */,
+				8969F32F2CB98B890063FFD1 /* ZeroCourseAlertsCell.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F3312CB98B890063FFD1 /* Course Alerts */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3232CB98B890063FFD1 /* Controllers */,
+				8969F3282CB98B890063FFD1 /* Model */,
+				8969F32A2CB98B890063FFD1 /* Networking */,
+				8969F3302CB98B890063FFD1 /* Views */,
+			);
+			path = "Course Alerts";
+			sourceTree = "<group>";
+		};
+		8969F3332CB98B890063FFD1 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3322CB98B890063FFD1 /* CoursesViewModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		8969F3372CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3342CB98B890063FFD1 /* CoursesDayView.swift */,
+				8969F3352CB98B890063FFD1 /* CoursesView.swift */,
+				8969F3362CB98B890063FFD1 /* CoursesViewController.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F3382CB98B890063FFD1 /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3332CB98B890063FFD1 /* Models */,
+				8969F3372CB98B890063FFD1 /* Views */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
+		8969F33A2CB98B890063FFD1 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3392CB98B890063FFD1 /* DiningLoginController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		8969F33D2CB98B890063FFD1 /* Cards */ = {
+			isa = PBXGroup;
+			children = (
+				8969F33B2CB98B890063FFD1 /* CardHeaderView.swift */,
+				8969F33C2CB98B890063FFD1 /* CardView.swift */,
+			);
+			path = Cards;
+			sourceTree = "<group>";
+		};
+		8969F3472CB98B890063FFD1 /* PredictionsGraph */ = {
+			isa = PBXGroup;
+			children = (
+				8969F33E2CB98B890063FFD1 /* DiningAnalyticsGraph.swift */,
+				8969F33F2CB98B890063FFD1 /* DiningAnalyticsGraphBox.swift */,
+				8969F3402CB98B890063FFD1 /* PredictionsGraphView.swift */,
+				8969F3412CB98B890063FFD1 /* PredictionsGraphView+AxisLabels.swift */,
+				8969F3422CB98B890063FFD1 /* PredictionsGraphView+SmoothedData.swift */,
+				8969F3432CB98B890063FFD1 /* VariableStepLineGraphView.swift */,
+				8969F3442CB98B890063FFD1 /* VariableStepLineGraphView+GraphEndpointPath.swift */,
+				8969F3452CB98B890063FFD1 /* VariableStepLineGraphView+PredictionSlopePath.swift */,
+				8969F3462CB98B890063FFD1 /* VariableStepLineGraphView+VariableStepGraphPath.swift */,
+			);
+			path = PredictionsGraph;
+			sourceTree = "<group>";
+		};
+		8969F34A2CB98B890063FFD1 /* Insights */ = {
+			isa = PBXGroup;
+			children = (
+				8969F33D2CB98B890063FFD1 /* Cards */,
+				8969F3472CB98B890063FFD1 /* PredictionsGraph */,
+				8969F3482CB98B890063FFD1 /* AnalyticsCardView.swift */,
+				8969F3492CB98B890063FFD1 /* DiningBalanceView.swift */,
+			);
+			path = Insights;
+			sourceTree = "<group>";
+		};
+		8969F3512CB98B890063FFD1 /* Detail View */ = {
+			isa = PBXGroup;
+			children = (
+				8969F34B2CB98B890063FFD1 /* DiningVenueDetailHoursView.swift */,
+				8969F34C2CB98B890063FFD1 /* DiningVenueDetailLocationView.swift */,
+				8969F34D2CB98B890063FFD1 /* DiningVenueDetailMenuView.swift */,
+				8969F34E2CB98B890063FFD1 /* DiningVenueDetailView.swift */,
+				8969F34F2CB98B890063FFD1 /* MenuDisclosureGroup.swift */,
+				8969F3502CB98B890063FFD1 /* mock_menu.json */,
+			);
+			path = "Detail View";
+			sourceTree = "<group>";
+		};
+		8969F3542CB98B890063FFD1 /* Venue */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3512CB98B890063FFD1 /* Detail View */,
+				8969F3522CB98B890063FFD1 /* DiningVenueView.swift */,
+				8969F3532CB98B890063FFD1 /* sample-dining-venue.json */,
+			);
+			path = Venue;
+			sourceTree = "<group>";
+		};
+		8969F3572CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F34A2CB98B890063FFD1 /* Insights */,
+				8969F3542CB98B890063FFD1 /* Venue */,
+				8969F3552CB98B890063FFD1 /* DiningView.swift */,
+				8969F3562CB98B890063FFD1 /* DiningViewHeader.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F35E2CB98B890063FFD1 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3572CB98B890063FFD1 /* Views */,
+				8969F3582CB98B890063FFD1 /* DiningAnalyticsView.swift */,
+				8969F3592CB98B890063FFD1 /* DiningLoginNavigationView.swift */,
+				8969F35A2CB98B890063FFD1 /* DiningLoginViewSwiftUI.swift */,
+				8969F35B2CB98B890063FFD1 /* DiningSettingsView.swift */,
+				8969F35C2CB98B890063FFD1 /* DiningViewControllerSwiftUI.swift */,
+				8969F35D2CB98B890063FFD1 /* DiningViewModelSwiftUI.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
+		8969F3602CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F35F2CB98B890063FFD1 /* DiningCell.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F3612CB98B890063FFD1 /* Dining */ = {
+			isa = PBXGroup;
+			children = (
+				8969F33A2CB98B890063FFD1 /* Controllers */,
+				8969F35E2CB98B890063FFD1 /* SwiftUI */,
+				8969F3602CB98B890063FFD1 /* Views */,
+			);
+			path = Dining;
+			sourceTree = "<group>";
+		};
+		8969F3662CB98B890063FFD1 /* Events */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3622CB98B890063FFD1 /* EventsAPI.swift */,
+				8969F3632CB98B890063FFD1 /* PennEvents.swift */,
+				8969F3642CB98B890063FFD1 /* PennEventsTableViewCell.swift */,
+				8969F3652CB98B890063FFD1 /* PennEventsTableViewController.swift */,
+			);
+			path = Events;
+			sourceTree = "<group>";
+		};
+		8969F36B2CB98B890063FFD1 /* Fitness */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3672CB98B890063FFD1 /* FitnessRoomRow.swift */,
+				8969F3682CB98B890063FFD1 /* FitnessSettingsView.swift */,
+				8969F3692CB98B890063FFD1 /* FitnessView.swift */,
+				8969F36A2CB98B890063FFD1 /* FitnessViewController.swift */,
+			);
+			path = Fitness;
+			sourceTree = "<group>";
+		};
+		8969F36F2CB98B890063FFD1 /* Generics */ = {
+			isa = PBXGroup;
+			children = (
+				8969F36C2CB98B890063FFD1 /* AnnouncementHeaderView.swift */,
+				8969F36D2CB98B890063FFD1 /* GenericControllers.swift */,
+				8969F36E2CB98B890063FFD1 /* MoveableTableViewController.swift */,
+			);
+			path = Generics;
+			sourceTree = "<group>";
+		};
+		8969F3752CB98B890063FFD1 /* ModularTableView */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3702CB98B890063FFD1 /* ModularTableView.swift */,
+				8969F3712CB98B890063FFD1 /* ModularTableViewCell.swift */,
+				8969F3722CB98B890063FFD1 /* ModularTableViewItem.swift */,
+				8969F3732CB98B890063FFD1 /* ModularTableViewItemTypes.swift */,
+				8969F3742CB98B890063FFD1 /* ModularTableViewModel.swift */,
+			);
+			path = ModularTableView;
+			sourceTree = "<group>";
+		};
+		8969F37B2CB98B890063FFD1 /* Networking + Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3762CB98B890063FFD1 /* FeedAnalyticsEngine.swift */,
+				8969F3772CB98B890063FFD1 /* FirebaseAnalyticsManager.swift */,
+				8969F3782CB98B890063FFD1 /* ImageNetworkingManager.swift */,
+				8969F3792CB98B890063FFD1 /* Networking.swift */,
+				8969F37A2CB98B890063FFD1 /* UserDBManager.swift */,
+			);
+			path = "Networking + Analytics";
+			sourceTree = "<group>";
+		};
+		8969F3822CB98B890063FFD1 /* SwiftUI Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F37C2CB98B890063FFD1 /* AlertModifier.swift */,
+				8969F37D2CB98B890063FFD1 /* BetaBadge.swift */,
+				8969F37E2CB98B890063FFD1 /* CustomPopupView.swift */,
+				8969F37F2CB98B890063FFD1 /* FadingScrollView.swift */,
+				8969F3802CB98B890063FFD1 /* SafariView.swift */,
+				8969F3812CB98B890063FFD1 /* UIKit Views.swift */,
+			);
+			path = "SwiftUI Views";
+			sourceTree = "<group>";
+		};
+		8969F3862CB98B890063FFD1 /* General */ = {
+			isa = PBXGroup;
+			children = (
+				8969F36F2CB98B890063FFD1 /* Generics */,
+				8969F3752CB98B890063FFD1 /* ModularTableView */,
+				8969F37B2CB98B890063FFD1 /* Networking + Analytics */,
+				8969F3822CB98B890063FFD1 /* SwiftUI Views */,
+				8969F3832CB98B890063FFD1 /* KeychainAccessible+Extensions.swift */,
+				8969F3842CB98B890063FFD1 /* Protocols.swift */,
+				8969F3852CB98B890063FFD1 /* UserDefaults + Helpers.swift */,
+			);
+			path = General;
+			sourceTree = "<group>";
+		};
+		8969F38C2CB98B890063FFD1 /* GSRGroups */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3872CB98B890063FFD1 /* GSRGroupConfirmBookingController.swift */,
+				8969F3882CB98B890063FFD1 /* GSRGroupController.swift */,
+				8969F3892CB98B890063FFD1 /* GSRGroupInviteViewController.swift */,
+				8969F38A2CB98B890063FFD1 /* GSRGroupNewIntialController.swift */,
+				8969F38B2CB98B890063FFD1 /* GSRManageGroupController.swift */,
+			);
+			path = GSRGroups;
+			sourceTree = "<group>";
+		};
+		8969F3932CB98B890063FFD1 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				8969F38C2CB98B890063FFD1 /* GSRGroups */,
+				8969F38D2CB98B890063FFD1 /* GSRBookable.swift */,
+				8969F38E2CB98B890063FFD1 /* GSRController.swift */,
+				8969F38F2CB98B890063FFD1 /* GSRDeletable.swift */,
+				8969F3902CB98B890063FFD1 /* GSRLocationsController.swift */,
+				8969F3912CB98B890063FFD1 /* GSRReservationsController.swift */,
+				8969F3922CB98B890063FFD1 /* GSRTabController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		8969F39E2CB98B890063FFD1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3942CB98B890063FFD1 /* GSRAPIResponse.swift */,
+				8969F3952CB98B890063FFD1 /* GSRBooking.swift */,
+				8969F3962CB98B890063FFD1 /* GSRDateHandler.swift */,
+				8969F3972CB98B890063FFD1 /* GSRGroup.swift */,
+				8969F3982CB98B890063FFD1 /* GSRGroupUser.swift */,
+				8969F3992CB98B890063FFD1 /* GSRLocation.swift */,
+				8969F39A2CB98B890063FFD1 /* GSRLocationModel.swift */,
+				8969F39B2CB98B890063FFD1 /* GSRReservation.swift */,
+				8969F39C2CB98B890063FFD1 /* GSRRoom.swift */,
+				8969F39D2CB98B890063FFD1 /* GSRTimeSlot.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8969F3A12CB98B890063FFD1 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F39F2CB98B890063FFD1 /* GSRGroupNetworkManager..swift */,
+				8969F3A02CB98B890063FFD1 /* GSRNetworkManager.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8969F3A42CB98B890063FFD1 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3A22CB98B890063FFD1 /* GSRManageGroupViewModel.swift */,
+				8969F3A32CB98B890063FFD1 /* GSRViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		8969F3AF2CB98B890063FFD1 /* GSRGroups */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3A52CB98B890063FFD1 /* CreateGroupCell.swift */,
+				8969F3A62CB98B890063FFD1 /* GroupCell.swift */,
+				8969F3A72CB98B890063FFD1 /* GroupHeaderCell.swift */,
+				8969F3A82CB98B890063FFD1 /* GroupIndividualSettingView.swift */,
+				8969F3A92CB98B890063FFD1 /* GroupInviteUserCell.swift */,
+				8969F3AA2CB98B890063FFD1 /* GroupManageButtonCell.swift */,
+				8969F3AB2CB98B890063FFD1 /* GroupMemberCell.swift */,
+				8969F3AC2CB98B890063FFD1 /* GroupSettingsCell.swift */,
+				8969F3AD2CB98B890063FFD1 /* GSRColorCell.swift */,
+				8969F3AE2CB98B890063FFD1 /* GSRGroupIconView.swift */,
+			);
+			path = GSRGroups;
+			sourceTree = "<group>";
+		};
+		8969F3B82CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3AF2CB98B890063FFD1 /* GSRGroups */,
+				8969F3B02CB98B890063FFD1 /* EmptyView.swift */,
+				8969F3B12CB98B890063FFD1 /* GSRClosedView.swift */,
+				8969F3B22CB98B890063FFD1 /* GSRLocationCell.swift */,
+				8969F3B32CB98B890063FFD1 /* GSRRangeSlider.swift */,
+				8969F3B42CB98B890063FFD1 /* GSRTimeCell.swift */,
+				8969F3B52CB98B890063FFD1 /* NoReservationsCell.swift */,
+				8969F3B62CB98B890063FFD1 /* ReservationCell.swift */,
+				8969F3B72CB98B890063FFD1 /* RoomCell.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F3BD2CB98B890063FFD1 /* ZMRangeSlider */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3B92CB98B890063FFD1 /* RangeSlider.swift */,
+				8969F3BA2CB98B890063FFD1 /* TextLayer.swift */,
+				8969F3BB2CB98B890063FFD1 /* ThumbLayer.swift */,
+				8969F3BC2CB98B890063FFD1 /* TrackLayer.swift */,
+			);
+			path = ZMRangeSlider;
+			sourceTree = "<group>";
+		};
+		8969F3BE2CB98B890063FFD1 /* GSR-Booking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3932CB98B890063FFD1 /* Controllers */,
+				8969F39E2CB98B890063FFD1 /* Model */,
+				8969F3A12CB98B890063FFD1 /* Networking */,
+				8969F3A42CB98B890063FFD1 /* ViewModel */,
+				8969F3B82CB98B890063FFD1 /* Views */,
+				8969F3BD2CB98B890063FFD1 /* ZMRangeSlider */,
+			);
+			path = "GSR-Booking";
+			sourceTree = "<group>";
+		};
+		8969F3C42CB98B890063FFD1 /* Calendar */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3BF2CB98B890063FFD1 /* CalendarAPI.swift */,
+				8969F3C02CB98B890063FFD1 /* CalendarEvent.swift */,
+				8969F3C12CB98B890063FFD1 /* HomeCalendarCell.swift */,
+				8969F3C22CB98B890063FFD1 /* HomeCalendarCellItem.swift */,
+				8969F3C32CB98B890063FFD1 /* UniversityNotificationCell.swift */,
+			);
+			path = Calendar;
+			sourceTree = "<group>";
+		};
+		8969F3C72CB98B890063FFD1 /* Dining */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3C52CB98B890063FFD1 /* HomeDiningCell.swift */,
+				8969F3C62CB98B890063FFD1 /* HomeDiningCellItem.swift */,
+			);
+			path = Dining;
+			sourceTree = "<group>";
+		};
+		8969F3CB2CB98B890063FFD1 /* Feature */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3C82CB98B890063FFD1 /* FeatureAnnouncement.swift */,
+				8969F3C92CB98B890063FFD1 /* HomeFeatureCell.swift */,
+				8969F3CA2CB98B890063FFD1 /* HomeFeatureCellItem.swift */,
+			);
+			path = Feature;
+			sourceTree = "<group>";
+		};
+		8969F3CF2CB98B890063FFD1 /* Group Invites */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3CC2CB98B890063FFD1 /* GSRGroupInviteCell.swift */,
+				8969F3CD2CB98B890063FFD1 /* HomeGroupInvitesCell.swift */,
+				8969F3CE2CB98B890063FFD1 /* HomeGroupInvitesCellItem.swift */,
+			);
+			path = "Group Invites";
+			sourceTree = "<group>";
+		};
+		8969F3D12CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3D02CB98B890063FFD1 /* BookingRowCell.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F3D52CB98B890063FFD1 /* GSR */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3D12CB98B890063FFD1 /* Views */,
+				8969F3D22CB98B890063FFD1 /* HomeGSRBookingButton.swift */,
+				8969F3D32CB98B890063FFD1 /* HomeGSRCellItem.swift */,
+				8969F3D42CB98B890063FFD1 /* HomeStudyRoomCell.swift */,
+			);
+			path = GSR;
+			sourceTree = "<group>";
+		};
+		8969F3D82CB98B890063FFD1 /* GSR Locations */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3D62CB98B890063FFD1 /* HomeGSRLocationsCell.swift */,
+				8969F3D72CB98B890063FFD1 /* HomeGSRLocationsCellItem.swift */,
+			);
+			path = "GSR Locations";
+			sourceTree = "<group>";
+		};
+		8969F3DB2CB98B890063FFD1 /* GSR Reservations */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3D92CB98B890063FFD1 /* HomeReservationsCell.swift */,
+				8969F3DA2CB98B890063FFD1 /* HomeReservationsCellItem.swift */,
+			);
+			path = "GSR Reservations";
+			sourceTree = "<group>";
+		};
+		8969F3DE2CB98B890063FFD1 /* Laundry */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3DC2CB98B890063FFD1 /* HomeLaundryCell.swift */,
+				8969F3DD2CB98B890063FFD1 /* HomeLaundryCellItem.swift */,
+			);
+			path = Laundry;
+			sourceTree = "<group>";
+		};
+		8969F3E32CB98B890063FFD1 /* News */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3DF2CB98B890063FFD1 /* HomeNewsCell.swift */,
+				8969F3E02CB98B890063FFD1 /* HomeNewsCellItem.swift */,
+				8969F3E12CB98B890063FFD1 /* NativeNewsViewController.swift */,
+				8969F3E22CB98B890063FFD1 /* NewsArticle.swift */,
+			);
+			path = News;
+			sourceTree = "<group>";
+		};
+		8969F3E92CB98B890063FFD1 /* Polls */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3E42CB98B890063FFD1 /* HomePollsCell.swift */,
+				8969F3E52CB98B890063FFD1 /* HomePollsCellFooter.swift */,
+				8969F3E62CB98B890063FFD1 /* HomePollsCellHeader.swift */,
+				8969F3E72CB98B890063FFD1 /* HomePollsCellItem.swift */,
+				8969F3E82CB98B890063FFD1 /* PollOptionCell.swift */,
+			);
+			path = Polls;
+			sourceTree = "<group>";
+		};
+		8969F3ED2CB98B890063FFD1 /* Post */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3EA2CB98B890063FFD1 /* HomePostCell.swift */,
+				8969F3EB2CB98B890063FFD1 /* HomePostCellItem.swift */,
+				8969F3EC2CB98B890063FFD1 /* Post.swift */,
+			);
+			path = Post;
+			sourceTree = "<group>";
+		};
+		8969F3F02CB98B890063FFD1 /* Spring Fling */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3EE2CB98B890063FFD1 /* HomeFlingCell.swift */,
+				8969F3EF2CB98B890063FFD1 /* HomeFlingCellItem.swift */,
+			);
+			path = "Spring Fling";
+			sourceTree = "<group>";
+		};
+		8969F3F22CB98B890063FFD1 /* Update */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3F12CB98B890063FFD1 /* HomeUpdateCellItem.swift */,
+			);
+			path = Update;
+			sourceTree = "<group>";
+		};
+		8969F3F72CB98B890063FFD1 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3C42CB98B890063FFD1 /* Calendar */,
+				8969F3C72CB98B890063FFD1 /* Dining */,
+				8969F3CB2CB98B890063FFD1 /* Feature */,
+				8969F3CF2CB98B890063FFD1 /* Group Invites */,
+				8969F3D52CB98B890063FFD1 /* GSR */,
+				8969F3D82CB98B890063FFD1 /* GSR Locations */,
+				8969F3DB2CB98B890063FFD1 /* GSR Reservations */,
+				8969F3DE2CB98B890063FFD1 /* Laundry */,
+				8969F3E32CB98B890063FFD1 /* News */,
+				8969F3E92CB98B890063FFD1 /* Polls */,
+				8969F3ED2CB98B890063FFD1 /* Post */,
+				8969F3F02CB98B890063FFD1 /* Spring Fling */,
+				8969F3F22CB98B890063FFD1 /* Update */,
+				8969F3F32CB98B890063FFD1 /* HomeCellConformable.swift */,
+				8969F3F42CB98B890063FFD1 /* HomeCellHeader.swift */,
+				8969F3F52CB98B890063FFD1 /* HomeCellProtocols.swift */,
+				8969F3F62CB98B890063FFD1 /* HomeCellSafeArea.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		8969F3FC2CB98B890063FFD1 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3F82CB98B890063FFD1 /* BuildingMapWebviewController.swift */,
+				8969F3F92CB98B890063FFD1 /* DiningCellSettingsController.swift */,
+				8969F3FA2CB98B890063FFD1 /* HomeViewController.swift */,
+				8969F3FB2CB98B890063FFD1 /* HomeViewController + Delegates.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		8969F4002CB98B890063FFD1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3FD2CB98B890063FFD1 /* HomeCellItem.swift */,
+				8969F3FE2CB98B890063FFD1 /* HomeItemTypes.swift */,
+				8969F3FF2CB98B890063FFD1 /* HomeTableViewModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8969F4022CB98B890063FFD1 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4012CB98B890063FFD1 /* HomeAPIService.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8969F4092CB98B890063FFD1 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				8969F3F72CB98B890063FFD1 /* Cells */,
+				8969F3FC2CB98B890063FFD1 /* Controllers */,
+				8969F4002CB98B890063FFD1 /* Model */,
+				8969F4022CB98B890063FFD1 /* Networking */,
+				8969F4032CB98B890063FFD1 /* CalendarCardView.swift */,
+				8969F4042CB98B890063FFD1 /* HomeCardView.swift */,
+				8969F4052CB98B890063FFD1 /* HomeSublettingBanner.swift */,
+				8969F4062CB98B890063FFD1 /* HomeView.swift */,
+				8969F4072CB98B890063FFD1 /* HomeViewData.swift */,
+				8969F4082CB98B890063FFD1 /* HomeViewModel.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		8969F40B2CB98B890063FFD1 /* Housing */ = {
+			isa = PBXGroup;
+			children = (
+				8969F40A2CB98B890063FFD1 /* Model.swift */,
+			);
+			path = Housing;
+			sourceTree = "<group>";
+		};
+		8969F4122CB98B890063FFD1 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				8969F40C2CB98B890063FFD1 /* AddLaundryCell.swift */,
+				8969F40D2CB98B890063FFD1 /* LaundryCell.swift */,
+				8969F40E2CB98B890063FFD1 /* LaundryCell + Graph.swift */,
+				8969F40F2CB98B890063FFD1 /* LaundryGraphView.swift */,
+				8969F4102CB98B890063FFD1 /* LaundryMachineCell.swift */,
+				8969F4112CB98B890063FFD1 /* LaundryMachinesView.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		8969F4162CB98B890063FFD1 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4132CB98B890063FFD1 /* LaundryMachineCellTappable.swift */,
+				8969F4142CB98B890063FFD1 /* LaundryTableViewController.swift */,
+				8969F4152CB98B890063FFD1 /* RoomSelectionViewController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		8969F4192CB98B890063FFD1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4172CB98B890063FFD1 /* LaundryNotificationCenter.swift */,
+				8969F4182CB98B890063FFD1 /* LaundryRoom.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8969F41B2CB98B890063FFD1 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F41A2CB98B890063FFD1 /* LaundryAPIService.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8969F41D2CB98B890063FFD1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8969F41C2CB98B890063FFD1 /* RoomSelectionView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8969F41E2CB98B890063FFD1 /* Laundry */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4122CB98B890063FFD1 /* Cells */,
+				8969F4162CB98B890063FFD1 /* Controllers */,
+				8969F4192CB98B890063FFD1 /* Model */,
+				8969F41B2CB98B890063FFD1 /* Networking */,
+				8969F41D2CB98B890063FFD1 /* Views */,
+			);
+			path = Laundry;
+			sourceTree = "<group>";
+		};
+		8969F42A2CB98B890063FFD1 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				8969F41F2CB98B890063FFD1 /* Account.swift */,
+				8969F4202CB98B890063FFD1 /* AuthManager.swift */,
+				8969F4212CB98B890063FFD1 /* CampusExpressLoginController.swift */,
+				8969F4222CB98B890063FFD1 /* CampusExpressNetworkManager.swift */,
+				8969F4232CB98B890063FFD1 /* Degree.swift */,
+				8969F4242CB98B890063FFD1 /* LabsLoginController.swift */,
+				8969F4252CB98B890063FFD1 /* LabsLoginSwiftUI.swift */,
+				8969F4262CB98B890063FFD1 /* LoggedOutView.swift */,
+				8969F4272CB98B890063FFD1 /* PathAtPennNetworkManager.swift */,
+				8969F4282CB98B890063FFD1 /* PennCashNetworkManager.swift */,
+				8969F4292CB98B890063FFD1 /* PennInTouchNetworkManager.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		8969F42E2CB98B890063FFD1 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				8969F42B2CB98B890063FFD1 /* AddressMapView.swift */,
+				8969F42C2CB98B890063FFD1 /* MapViewController.swift */,
+				8969F42D2CB98B890063FFD1 /* PennCoordinate.swift */,
+			);
+			path = Map;
+			sourceTree = "<group>";
+		};
+		8969F4312CB98B890063FFD1 /* PAC Code */ = {
+			isa = PBXGroup;
+			children = (
+				8969F42F2CB98B890063FFD1 /* PacCodeNetworkManager.swift */,
+				8969F4302CB98B890063FFD1 /* PacCodeViewController.swift */,
+			);
+			path = "PAC Code";
+			sourceTree = "<group>";
+		};
+		8969F4332CB98B890063FFD1 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4322CB98B890063FFD1 /* ProfilePageNetworkManager.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8969F43A2CB98B890063FFD1 /* Profile Page */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4332CB98B890063FFD1 /* Networking */,
+				8969F4342CB98B890063FFD1 /* InfoTableViewController.swift */,
+				8969F4352CB98B890063FFD1 /* InfoTableViewModel.swift */,
+				8969F4362CB98B890063FFD1 /* ProfilePageTableViewCell.swift */,
+				8969F4372CB98B890063FFD1 /* ProfilePageViewController.swift */,
+				8969F4382CB98B890063FFD1 /* ProfilePageViewModel.swift */,
+				8969F4392CB98B890063FFD1 /* ProfilePictureTableViewCell.swift */,
+			);
+			path = "Profile Page";
+			sourceTree = "<group>";
+		};
+		8969F4422CB98B890063FFD1 /* More Tab */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4312CB98B890063FFD1 /* PAC Code */,
+				8969F43A2CB98B890063FFD1 /* Profile Page */,
+				8969F43B2CB98B890063FFD1 /* AboutViewController.swift */,
+				8969F43C2CB98B890063FFD1 /* HeaderViewCell.swift */,
+				8969F43D2CB98B890063FFD1 /* MoreCell.swift */,
+				8969F43E2CB98B890063FFD1 /* MoreHeaderView.swift */,
+				8969F43F2CB98B890063FFD1 /* MoreView.swift */,
+				8969F4402CB98B890063FFD1 /* MoreViewController.swift */,
+				8969F4412CB98B890063FFD1 /* ProfileRowView.swift */,
+			);
+			path = "More Tab";
+			sourceTree = "<group>";
+		};
+		8969F4442CB98B890063FFD1 /* News */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4432CB98B890063FFD1 /* NewsViewController.swift */,
+			);
+			path = News;
+			sourceTree = "<group>";
+		};
+		8969F4472CB98B890063FFD1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4452CB98B890063FFD1 /* NotificationAPIModel.swift */,
+				8969F4462CB98B890063FFD1 /* NotificationsSetting.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8969F44B2CB98B890063FFD1 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4482CB98B890063FFD1 /* NotificationsView.swift */,
+				8969F4492CB98B890063FFD1 /* NotificationsViewControllerSwiftUI.swift */,
+				8969F44A2CB98B890063FFD1 /* NotificationViewModel.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
+		8969F4502CB98B890063FFD1 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4472CB98B890063FFD1 /* Model */,
+				8969F44B2CB98B890063FFD1 /* SwiftUI */,
+				8969F44C2CB98B890063FFD1 /* NotificationPreference.swift */,
+				8969F44D2CB98B890063FFD1 /* NotificationRequestable.swift */,
+				8969F44E2CB98B890063FFD1 /* NotificationsTableViewCell.swift */,
+				8969F44F2CB98B890063FFD1 /* NotificationsTableViewController.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		8969F4562CB98B890063FFD1 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4512CB98B890063FFD1 /* OnboardingController.swift */,
+				8969F4522CB98B890063FFD1 /* Page.swift */,
+				8969F4532CB98B890063FFD1 /* PageCell.swift */,
+				8969F4542CB98B890063FFD1 /* SAConfettiView.swift */,
+				8969F4552CB98B890063FFD1 /* SelectionCell.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		8969F45C2CB98B890063FFD1 /* Penn Mobile AI */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4572CB98B890063FFD1 /* AIChatModel.swift */,
+				8969F4582CB98B890063FFD1 /* AIChatView.swift */,
+				8969F4592CB98B890063FFD1 /* AIChatViewModel.swift */,
+				8969F45A2CB98B890063FFD1 /* ChatMessage.swift */,
+				8969F45B2CB98B890063FFD1 /* ChatMessageView.swift */,
+			);
+			path = "Penn Mobile AI";
+			sourceTree = "<group>";
+		};
+		8969F45E2CB98B890063FFD1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				8969F45D2CB98B890063FFD1 /* PollQuestion.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8969F4602CB98B890063FFD1 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				8969F45F2CB98B890063FFD1 /* PollsNetworkManager.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8969F4642CB98B890063FFD1 /* Polls */ = {
+			isa = PBXGroup;
+			children = (
+				8969F45E2CB98B890063FFD1 /* Model */,
+				8969F4602CB98B890063FFD1 /* Networking */,
+				8969F4612CB98B890063FFD1 /* PollsView.swift */,
+				8969F4622CB98B890063FFD1 /* PollsViewController.swift */,
+				8969F4632CB98B890063FFD1 /* PollView.swift */,
+			);
+			path = Polls;
+			sourceTree = "<group>";
+		};
+		8969F4672CB98B890063FFD1 /* Preferences */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4652CB98B890063FFD1 /* PreferencesView.swift */,
+				8969F4662CB98B890063FFD1 /* PreferencesViewController.swift */,
+			);
+			path = Preferences;
+			sourceTree = "<group>";
+		};
+		8969F46D2CB98B890063FFD1 /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4682CB98B890063FFD1 /* PermissionView.swift */,
+				8969F4692CB98B890063FFD1 /* PrivacyPermissionDelegate.swift */,
+				8969F46A2CB98B890063FFD1 /* PrivacyPreference.swift */,
+				8969F46B2CB98B890063FFD1 /* PrivacyTableViewCell.swift */,
+				8969F46C2CB98B890063FFD1 /* PrivacyTableViewController.swift */,
+			);
+			path = Privacy;
+			sourceTree = "<group>";
+		};
+		8969F47A2CB98B890063FFD1 /* Setup + Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				8969F46E2CB98B890063FFD1 /* AppDelegate.swift */,
+				8969F46F2CB98B890063FFD1 /* AppDelegate+NotificationExtension.swift */,
+				8969F4702CB98B890063FFD1 /* ControllerModel.swift */,
+				8969F4712CB98B890063FFD1 /* Environment.swift */,
+				8969F4722CB98B890063FFD1 /* Features.swift */,
+				8969F4732CB98B890063FFD1 /* MainTabView.swift */,
+				8969F4742CB98B890063FFD1 /* PennMobile.swift */,
+				8969F4752CB98B890063FFD1 /* RootView.swift */,
+				8969F4762CB98B890063FFD1 /* RootViewController.swift */,
+				8969F4772CB98B890063FFD1 /* SplashViewController.swift */,
+				8969F4782CB98B890063FFD1 /* TabBarController.swift */,
+				8969F4792CB98B890063FFD1 /* Toasts.swift */,
+			);
+			path = "Setup + Navigation";
+			sourceTree = "<group>";
+		};
+		8969F47D2CB98B890063FFD1 /* Listings */ = {
+			isa = PBXGroup;
+			children = (
+				8969F47B2CB98B890063FFD1 /* MyListingsActivity.swift */,
+				8969F47C2CB98B890063FFD1 /* NewListingForm.swift */,
+			);
+			path = Listings;
+			sourceTree = "<group>";
+		};
+		8969F4872CB98B890063FFD1 /* Subletting */ = {
+			isa = PBXGroup;
+			children = (
+				8969F47D2CB98B890063FFD1 /* Listings */,
+				8969F47E2CB98B890063FFD1 /* MarketplaceFilterView.swift */,
+				8969F47F2CB98B890063FFD1 /* MarketplaceView.swift */,
+				8969F4802CB98B890063FFD1 /* SubletCandidatesView.swift */,
+				8969F4812CB98B890063FFD1 /* SubletDetailView.swift */,
+				8969F4822CB98B890063FFD1 /* SubletDisplayRow.swift */,
+				8969F4832CB98B890063FFD1 /* SubletInterestForm.swift */,
+				8969F4842CB98B890063FFD1 /* SubletMapView.swift */,
+				8969F4852CB98B890063FFD1 /* SublettingAPI.swift */,
+				8969F4862CB98B890063FFD1 /* SublettingViewModel.swift */,
+			);
+			path = Subletting;
+			sourceTree = "<group>";
+		};
+		8969F48C2CB98B890063FFD1 /* Supporting_Files */ = {
+			isa = PBXGroup;
+			children = (
+				8969F4882CB98B890063FFD1 /* GoogleService-Info.plist */,
+				8969F4892CB98B890063FFD1 /* Info.plist */,
+				8969F48A2CB98B890063FFD1 /* PennMobile-Bridging-Header.h */,
+				8969F48B2CB98B890063FFD1 /* PrefixHeader.pch */,
+			);
+			path = Supporting_Files;
+			sourceTree = "<group>";
+		};
+		8969F48F2CB98B890063FFD1 /* PennMobile */ = {
+			isa = PBXGroup;
+			children = (
+				8969F2FD2CB98B890063FFD1 /* Auth */,
+				8969F3022CB98B890063FFD1 /* Banners */,
+				8969F30E2CB98B890063FFD1 /* Buildings */,
+				8969F3192CB98B890063FFD1 /* Clubs */,
+				8969F31F2CB98B890063FFD1 /* Contacts */,
+				8969F3312CB98B890063FFD1 /* Course Alerts */,
+				8969F3382CB98B890063FFD1 /* Courses */,
+				8969F3612CB98B890063FFD1 /* Dining */,
+				8969F3662CB98B890063FFD1 /* Events */,
+				8969F36B2CB98B890063FFD1 /* Fitness */,
+				8969F3862CB98B890063FFD1 /* General */,
+				8969F3BE2CB98B890063FFD1 /* GSR-Booking */,
+				8969F4092CB98B890063FFD1 /* Home */,
+				8969F40B2CB98B890063FFD1 /* Housing */,
+				8969F41E2CB98B890063FFD1 /* Laundry */,
+				8969F42A2CB98B890063FFD1 /* Login */,
+				8969F42E2CB98B890063FFD1 /* Map */,
+				8969F4422CB98B890063FFD1 /* More Tab */,
+				8969F4442CB98B890063FFD1 /* News */,
+				8969F4502CB98B890063FFD1 /* Notifications */,
+				8969F4562CB98B890063FFD1 /* Onboarding */,
+				8969F45C2CB98B890063FFD1 /* Penn Mobile AI */,
+				8969F4642CB98B890063FFD1 /* Polls */,
+				8969F4672CB98B890063FFD1 /* Preferences */,
+				8969F46D2CB98B890063FFD1 /* Privacy */,
+				8969F47A2CB98B890063FFD1 /* Setup + Navigation */,
+				8969F4872CB98B890063FFD1 /* Subletting */,
+				8969F48C2CB98B890063FFD1 /* Supporting_Files */,
+				8969F48D2CB98B890063FFD1 /* Assets.xcassets */,
+				8969F48E2CB98B890063FFD1 /* PennMobile.entitlements */,
+			);
+			path = PennMobile;
+			sourceTree = "<group>";
+		};
+		8969F5CB2CB98B8B0063FFD1 /* NotificationServiceExtension */ = {
+			isa = PBXGroup;
+			children = (
+				8969F5C82CB98B8B0063FFD1 /* Info.plist */,
+				8969F5C92CB98B8B0063FFD1 /* NotificationService.swift */,
+				8969F5CA2CB98B8B0063FFD1 /* NotificationService+ImageCacheing.swift */,
+			);
+			path = NotificationServiceExtension;
+			sourceTree = "<group>";
+		};
+		8969F5CE2CB98B900063FFD1 /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+				8969F5CC2CB98B900063FFD1 /* CoursesDayWidget.swift */,
+				8969F5CD2CB98B900063FFD1 /* CoursesProvider.swift */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
+		8969F5D12CB98B900063FFD1 /* Dining */ = {
+			isa = PBXGroup;
+			children = (
+				8969F5CF2CB98B900063FFD1 /* DiningAnalyticsHomeWidget.swift */,
+				8969F5D02CB98B900063FFD1 /* DiningAnalyticsProvider.swift */,
+			);
+			path = Dining;
+			sourceTree = "<group>";
+		};
+		8969F5D42CB98B900063FFD1 /* Dining Hours */ = {
+			isa = PBXGroup;
+			children = (
+				8969F5D22CB98B900063FFD1 /* DiningHoursProvider.swift */,
+				8969F5D32CB98B900063FFD1 /* DiningHoursWidget.swift */,
+			);
+			path = "Dining Hours";
+			sourceTree = "<group>";
+		};
+		8969F5D72CB98B900063FFD1 /* Fitness */ = {
+			isa = PBXGroup;
+			children = (
+				8969F5D52CB98B900063FFD1 /* FitnessProvider.swift */,
+				8969F5D62CB98B900063FFD1 /* FitnessWidget.swift */,
+			);
+			path = Fitness;
+			sourceTree = "<group>";
+		};
+		8969F5E02CB98B900063FFD1 /* Widget */ = {
+			isa = PBXGroup;
+			children = (
+				8969F5CE2CB98B900063FFD1 /* Courses */,
+				8969F5D12CB98B900063FFD1 /* Dining */,
+				8969F5D42CB98B900063FFD1 /* Dining Hours */,
+				8969F5D72CB98B900063FFD1 /* Fitness */,
+				8969F5D82CB98B900063FFD1 /* Assets.xcassets */,
+				8969F5D92CB98B900063FFD1 /* ConfigurationRepresenting.swift */,
+				8969F5DA2CB98B900063FFD1 /* Info.plist */,
+				8969F5DB2CB98B900063FFD1 /* LaundryLiveActivity.swift */,
+				8969F5DC2CB98B900063FFD1 /* ViewExtensions.swift */,
+				8969F5DD2CB98B900063FFD1 /* WidgetBackgroundTypeExtensions.swift */,
+				8969F5DE2CB98B900063FFD1 /* WidgetBundle.swift */,
+				8969F5DF2CB98B900063FFD1 /* WidgetExtension.entitlements */,
+			);
+			path = Widget;
+			sourceTree = "<group>";
+		};
 		F5E2CE9A9024AE8E28992A5E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -271,6 +2176,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8969F2D92CB98B860063FFD1 /* PennMobileShared.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -296,9 +2202,6 @@
 			dependencies = (
 				8932694328FC75A6003D4BF9 /* PBXTargetDependency */,
 				6E4D821B2AC8C91C009AB78E /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				89A702AE2C9876F00070DF19 /* PennMobile */,
 			);
 			name = PennMobile;
 			packageProductDependencies = (
@@ -327,9 +2230,6 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-				892B2D522C9874A800CD769A /* PennMobileShared */,
-			);
 			name = PennMobileShared;
 			packageProductDependencies = (
 				6E5159F82AC8D88A004B3F41 /* SwiftyJSON */,
@@ -351,9 +2251,6 @@
 			);
 			dependencies = (
 				6E5159F62AC8CA1B004B3F41 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				89A7FDF22C9875470070DF19 /* Widget */,
 			);
 			name = WidgetExtension;
 			packageProductDependencies = (
@@ -459,6 +2356,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4273BCFF2BD2D8D80070C1B8 /* PrivacyInfo.xcprivacy in Resources */,
+				8969F5BF2CB98B890063FFD1 /* ScannerDuplicate.ahap in Resources */,
+				8969F5C02CB98B890063FFD1 /* ScannerError.ahap in Resources */,
+				8969F5C12CB98B890063FFD1 /* ScannerInvalid.ahap in Resources */,
+				8969F5C22CB98B890063FFD1 /* ScannerValid.ahap in Resources */,
+				8969F5C32CB98B890063FFD1 /* mock_menu.json in Resources */,
+				8969F5C42CB98B890063FFD1 /* sample-dining-venue.json in Resources */,
+				8969F5C52CB98B890063FFD1 /* GoogleService-Info.plist in Resources */,
+				8969F5C72CB98B890063FFD1 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -474,6 +2379,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8969F5E12CB98B900063FFD1 /* Assets.xcassets in Resources */,
 				4273BD012BD2D8D80070C1B8 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -599,6 +2505,309 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8969F4902CB98B890063FFD1 /* OAuth2NetworkManager.swift in Sources */,
+				8969F4912CB98B890063FFD1 /* PennAuthRequestable.swift in Sources */,
+				8969F4922CB98B890063FFD1 /* PennLoginController.swift in Sources */,
+				8969F4932CB98B890063FFD1 /* BannerDescription.swift in Sources */,
+				8969F4942CB98B890063FFD1 /* BannerView.swift in Sources */,
+				8969F4952CB98B890063FFD1 /* BannerViewModel.swift in Sources */,
+				8969F4962CB98B890063FFD1 /* UserEngagementPopupView.swift in Sources */,
+				8969F4972CB98B890063FFD1 /* BuildingCell.swift in Sources */,
+				8969F4982CB98B890063FFD1 /* BuildingFoodMenuCell.swift in Sources */,
+				8969F4992CB98B890063FFD1 /* BuildingHeaderCell.swift in Sources */,
+				8969F49A2CB98B890063FFD1 /* BuildingHoursCell.swift in Sources */,
+				8969F49B2CB98B890063FFD1 /* BuildingImageCell.swift in Sources */,
+				8969F49C2CB98B890063FFD1 /* BuildingMapCell.swift in Sources */,
+				8969F49D2CB98B890063FFD1 /* BuildingSectionHeader.swift in Sources */,
+				8969F49E2CB98B890063FFD1 /* MenuTableView.swift in Sources */,
+				8969F49F2CB98B890063FFD1 /* BuildingProtocol.swift in Sources */,
+				8969F4A02CB98B890063FFD1 /* ScannerState.swift in Sources */,
+				8969F4A12CB98B890063FFD1 /* ScannerView.swift in Sources */,
+				8969F4A22CB98B890063FFD1 /* ScannerViewfinder.swift in Sources */,
+				8969F4A32CB98B890063FFD1 /* ScannerViewModel.swift in Sources */,
+				8969F4A42CB98B890063FFD1 /* TicketingAPI.swift in Sources */,
+				8969F4A52CB98B890063FFD1 /* ContactCell.swift in Sources */,
+				8969F4A62CB98B890063FFD1 /* ContactManager.swift in Sources */,
+				8969F4A72CB98B890063FFD1 /* ContactsTableViewController.swift in Sources */,
+				8969F4A82CB98B890063FFD1 /* SupportItem.m in Sources */,
+				8969F4A92CB98B890063FFD1 /* CourseAlertController.swift in Sources */,
+				8969F4AA2CB98B890063FFD1 /* CourseAlertCreateController.swift in Sources */,
+				8969F4AB2CB98B890063FFD1 /* CourseAlertSettingsController.swift in Sources */,
+				8969F4AC2CB98B890063FFD1 /* CourseAlert.swift in Sources */,
+				8969F4AD2CB98B890063FFD1 /* CourseAlertSettings.swift in Sources */,
+				8969F4AE2CB98B890063FFD1 /* CourseAlertSettingsOptions.swift in Sources */,
+				8969F4AF2CB98B890063FFD1 /* CourseSection.swift in Sources */,
+				8969F4B02CB98B890063FFD1 /* CourseAlertNetworkManager.swift in Sources */,
+				8969F4B12CB98B890063FFD1 /* CourseAlertCell.swift in Sources */,
+				8969F4B22CB98B890063FFD1 /* CourseAlertCreateCell.swift in Sources */,
+				8969F4B32CB98B890063FFD1 /* CourseAlertSettingsCell.swift in Sources */,
+				8969F4B42CB98B890063FFD1 /* SearchResultsCell.swift in Sources */,
+				8969F4B52CB98B890063FFD1 /* ZeroCourseAlertsCell.swift in Sources */,
+				8969F4B62CB98B890063FFD1 /* CoursesViewModel.swift in Sources */,
+				8969F4B72CB98B890063FFD1 /* CoursesDayView.swift in Sources */,
+				8969F4B82CB98B890063FFD1 /* CoursesView.swift in Sources */,
+				8969F4B92CB98B890063FFD1 /* CoursesViewController.swift in Sources */,
+				8969F4BA2CB98B890063FFD1 /* DiningLoginController.swift in Sources */,
+				8969F4BB2CB98B890063FFD1 /* CardHeaderView.swift in Sources */,
+				8969F4BC2CB98B890063FFD1 /* CardView.swift in Sources */,
+				8969F4BD2CB98B890063FFD1 /* DiningAnalyticsGraph.swift in Sources */,
+				8969F4BE2CB98B890063FFD1 /* DiningAnalyticsGraphBox.swift in Sources */,
+				8969F4BF2CB98B890063FFD1 /* PredictionsGraphView.swift in Sources */,
+				8969F4C02CB98B890063FFD1 /* PredictionsGraphView+AxisLabels.swift in Sources */,
+				8969F4C12CB98B890063FFD1 /* PredictionsGraphView+SmoothedData.swift in Sources */,
+				8969F4C22CB98B890063FFD1 /* VariableStepLineGraphView.swift in Sources */,
+				8969F4C32CB98B890063FFD1 /* VariableStepLineGraphView+GraphEndpointPath.swift in Sources */,
+				8969F4C42CB98B890063FFD1 /* VariableStepLineGraphView+PredictionSlopePath.swift in Sources */,
+				8969F4C52CB98B890063FFD1 /* VariableStepLineGraphView+VariableStepGraphPath.swift in Sources */,
+				8969F4C62CB98B890063FFD1 /* AnalyticsCardView.swift in Sources */,
+				8969F4C72CB98B890063FFD1 /* DiningBalanceView.swift in Sources */,
+				8969F4C82CB98B890063FFD1 /* DiningVenueDetailHoursView.swift in Sources */,
+				8969F4C92CB98B890063FFD1 /* DiningVenueDetailLocationView.swift in Sources */,
+				8969F4CA2CB98B890063FFD1 /* DiningVenueDetailMenuView.swift in Sources */,
+				8969F4CB2CB98B890063FFD1 /* DiningVenueDetailView.swift in Sources */,
+				8969F4CC2CB98B890063FFD1 /* MenuDisclosureGroup.swift in Sources */,
+				8969F4CD2CB98B890063FFD1 /* DiningVenueView.swift in Sources */,
+				8969F4CE2CB98B890063FFD1 /* DiningView.swift in Sources */,
+				8969F4CF2CB98B890063FFD1 /* DiningViewHeader.swift in Sources */,
+				8969F4D02CB98B890063FFD1 /* DiningAnalyticsView.swift in Sources */,
+				8969F4D12CB98B890063FFD1 /* DiningLoginNavigationView.swift in Sources */,
+				8969F4D22CB98B890063FFD1 /* DiningLoginViewSwiftUI.swift in Sources */,
+				8969F4D32CB98B890063FFD1 /* DiningSettingsView.swift in Sources */,
+				8969F4D42CB98B890063FFD1 /* DiningViewControllerSwiftUI.swift in Sources */,
+				8969F4D52CB98B890063FFD1 /* DiningViewModelSwiftUI.swift in Sources */,
+				8969F4D62CB98B890063FFD1 /* DiningCell.swift in Sources */,
+				8969F4D72CB98B890063FFD1 /* EventsAPI.swift in Sources */,
+				8969F4D82CB98B890063FFD1 /* PennEvents.swift in Sources */,
+				8969F4D92CB98B890063FFD1 /* PennEventsTableViewCell.swift in Sources */,
+				8969F4DA2CB98B890063FFD1 /* PennEventsTableViewController.swift in Sources */,
+				8969F4DB2CB98B890063FFD1 /* FitnessRoomRow.swift in Sources */,
+				8969F4DC2CB98B890063FFD1 /* FitnessSettingsView.swift in Sources */,
+				8969F4DD2CB98B890063FFD1 /* FitnessView.swift in Sources */,
+				8969F4DE2CB98B890063FFD1 /* FitnessViewController.swift in Sources */,
+				8969F4DF2CB98B890063FFD1 /* AnnouncementHeaderView.swift in Sources */,
+				8969F4E02CB98B890063FFD1 /* GenericControllers.swift in Sources */,
+				8969F4E12CB98B890063FFD1 /* MoveableTableViewController.swift in Sources */,
+				8969F4E22CB98B890063FFD1 /* ModularTableView.swift in Sources */,
+				8969F4E32CB98B890063FFD1 /* ModularTableViewCell.swift in Sources */,
+				8969F4E42CB98B890063FFD1 /* ModularTableViewItem.swift in Sources */,
+				8969F4E52CB98B890063FFD1 /* ModularTableViewItemTypes.swift in Sources */,
+				8969F4E62CB98B890063FFD1 /* ModularTableViewModel.swift in Sources */,
+				8969F4E72CB98B890063FFD1 /* FeedAnalyticsEngine.swift in Sources */,
+				8969F4E82CB98B890063FFD1 /* FirebaseAnalyticsManager.swift in Sources */,
+				8969F4E92CB98B890063FFD1 /* ImageNetworkingManager.swift in Sources */,
+				8969F4EA2CB98B890063FFD1 /* Networking.swift in Sources */,
+				8969F4EB2CB98B890063FFD1 /* UserDBManager.swift in Sources */,
+				8969F4EC2CB98B890063FFD1 /* AlertModifier.swift in Sources */,
+				8969F4ED2CB98B890063FFD1 /* BetaBadge.swift in Sources */,
+				8969F4EE2CB98B890063FFD1 /* CustomPopupView.swift in Sources */,
+				8969F4EF2CB98B890063FFD1 /* FadingScrollView.swift in Sources */,
+				8969F4F02CB98B890063FFD1 /* SafariView.swift in Sources */,
+				8969F4F12CB98B890063FFD1 /* UIKit Views.swift in Sources */,
+				8969F4F22CB98B890063FFD1 /* KeychainAccessible+Extensions.swift in Sources */,
+				8969F4F32CB98B890063FFD1 /* Protocols.swift in Sources */,
+				8969F4F42CB98B890063FFD1 /* UserDefaults + Helpers.swift in Sources */,
+				8969F4F52CB98B890063FFD1 /* GSRGroupConfirmBookingController.swift in Sources */,
+				8969F4F62CB98B890063FFD1 /* GSRGroupController.swift in Sources */,
+				8969F4F72CB98B890063FFD1 /* GSRGroupInviteViewController.swift in Sources */,
+				8969F4F82CB98B890063FFD1 /* GSRGroupNewIntialController.swift in Sources */,
+				8969F4F92CB98B890063FFD1 /* GSRManageGroupController.swift in Sources */,
+				8969F4FA2CB98B890063FFD1 /* GSRBookable.swift in Sources */,
+				8969F4FB2CB98B890063FFD1 /* GSRController.swift in Sources */,
+				8969F4FC2CB98B890063FFD1 /* GSRDeletable.swift in Sources */,
+				8969F4FD2CB98B890063FFD1 /* GSRLocationsController.swift in Sources */,
+				8969F4FE2CB98B890063FFD1 /* GSRReservationsController.swift in Sources */,
+				8969F4FF2CB98B890063FFD1 /* GSRTabController.swift in Sources */,
+				8969F5002CB98B890063FFD1 /* GSRAPIResponse.swift in Sources */,
+				8969F5012CB98B890063FFD1 /* GSRBooking.swift in Sources */,
+				8969F5022CB98B890063FFD1 /* GSRDateHandler.swift in Sources */,
+				8969F5032CB98B890063FFD1 /* GSRGroup.swift in Sources */,
+				8969F5042CB98B890063FFD1 /* GSRGroupUser.swift in Sources */,
+				8969F5052CB98B890063FFD1 /* GSRLocation.swift in Sources */,
+				8969F5062CB98B890063FFD1 /* GSRLocationModel.swift in Sources */,
+				8969F5072CB98B890063FFD1 /* GSRReservation.swift in Sources */,
+				8969F5082CB98B890063FFD1 /* GSRRoom.swift in Sources */,
+				8969F5092CB98B890063FFD1 /* GSRTimeSlot.swift in Sources */,
+				8969F50A2CB98B890063FFD1 /* GSRGroupNetworkManager..swift in Sources */,
+				8969F50B2CB98B890063FFD1 /* GSRNetworkManager.swift in Sources */,
+				8969F50C2CB98B890063FFD1 /* GSRManageGroupViewModel.swift in Sources */,
+				8969F50D2CB98B890063FFD1 /* GSRViewModel.swift in Sources */,
+				8969F50E2CB98B890063FFD1 /* CreateGroupCell.swift in Sources */,
+				8969F50F2CB98B890063FFD1 /* GroupCell.swift in Sources */,
+				8969F5102CB98B890063FFD1 /* GroupHeaderCell.swift in Sources */,
+				8969F5112CB98B890063FFD1 /* GroupIndividualSettingView.swift in Sources */,
+				8969F5122CB98B890063FFD1 /* GroupInviteUserCell.swift in Sources */,
+				8969F5132CB98B890063FFD1 /* GroupManageButtonCell.swift in Sources */,
+				8969F5142CB98B890063FFD1 /* GroupMemberCell.swift in Sources */,
+				8969F5152CB98B890063FFD1 /* GroupSettingsCell.swift in Sources */,
+				8969F5162CB98B890063FFD1 /* GSRColorCell.swift in Sources */,
+				8969F5172CB98B890063FFD1 /* GSRGroupIconView.swift in Sources */,
+				8969F5182CB98B890063FFD1 /* EmptyView.swift in Sources */,
+				8969F5192CB98B890063FFD1 /* GSRClosedView.swift in Sources */,
+				8969F51A2CB98B890063FFD1 /* GSRLocationCell.swift in Sources */,
+				8969F51B2CB98B890063FFD1 /* GSRRangeSlider.swift in Sources */,
+				8969F51C2CB98B890063FFD1 /* GSRTimeCell.swift in Sources */,
+				8969F51D2CB98B890063FFD1 /* NoReservationsCell.swift in Sources */,
+				8969F51E2CB98B890063FFD1 /* ReservationCell.swift in Sources */,
+				8969F51F2CB98B890063FFD1 /* RoomCell.swift in Sources */,
+				8969F5202CB98B890063FFD1 /* RangeSlider.swift in Sources */,
+				8969F5212CB98B890063FFD1 /* TextLayer.swift in Sources */,
+				8969F5222CB98B890063FFD1 /* ThumbLayer.swift in Sources */,
+				8969F5232CB98B890063FFD1 /* TrackLayer.swift in Sources */,
+				8969F5242CB98B890063FFD1 /* CalendarAPI.swift in Sources */,
+				8969F5252CB98B890063FFD1 /* CalendarEvent.swift in Sources */,
+				8969F5262CB98B890063FFD1 /* HomeCalendarCell.swift in Sources */,
+				8969F5272CB98B890063FFD1 /* HomeCalendarCellItem.swift in Sources */,
+				8969F5282CB98B890063FFD1 /* UniversityNotificationCell.swift in Sources */,
+				8969F5292CB98B890063FFD1 /* HomeDiningCell.swift in Sources */,
+				8969F52A2CB98B890063FFD1 /* HomeDiningCellItem.swift in Sources */,
+				8969F52B2CB98B890063FFD1 /* FeatureAnnouncement.swift in Sources */,
+				8969F52C2CB98B890063FFD1 /* HomeFeatureCell.swift in Sources */,
+				8969F52D2CB98B890063FFD1 /* HomeFeatureCellItem.swift in Sources */,
+				8969F52E2CB98B890063FFD1 /* GSRGroupInviteCell.swift in Sources */,
+				8969F52F2CB98B890063FFD1 /* HomeGroupInvitesCell.swift in Sources */,
+				8969F5302CB98B890063FFD1 /* HomeGroupInvitesCellItem.swift in Sources */,
+				8969F5312CB98B890063FFD1 /* BookingRowCell.swift in Sources */,
+				8969F5322CB98B890063FFD1 /* HomeGSRBookingButton.swift in Sources */,
+				8969F5332CB98B890063FFD1 /* HomeGSRCellItem.swift in Sources */,
+				8969F5342CB98B890063FFD1 /* HomeStudyRoomCell.swift in Sources */,
+				8969F5352CB98B890063FFD1 /* HomeGSRLocationsCell.swift in Sources */,
+				8969F5362CB98B890063FFD1 /* HomeGSRLocationsCellItem.swift in Sources */,
+				8969F5372CB98B890063FFD1 /* HomeReservationsCell.swift in Sources */,
+				8969F5382CB98B890063FFD1 /* HomeReservationsCellItem.swift in Sources */,
+				8969F5392CB98B890063FFD1 /* HomeLaundryCell.swift in Sources */,
+				8969F53A2CB98B890063FFD1 /* HomeLaundryCellItem.swift in Sources */,
+				8969F53B2CB98B890063FFD1 /* HomeNewsCell.swift in Sources */,
+				8969F53C2CB98B890063FFD1 /* HomeNewsCellItem.swift in Sources */,
+				8969F53D2CB98B890063FFD1 /* NativeNewsViewController.swift in Sources */,
+				8969F53E2CB98B890063FFD1 /* NewsArticle.swift in Sources */,
+				8969F53F2CB98B890063FFD1 /* HomePollsCell.swift in Sources */,
+				8969F5402CB98B890063FFD1 /* HomePollsCellFooter.swift in Sources */,
+				8969F5412CB98B890063FFD1 /* HomePollsCellHeader.swift in Sources */,
+				8969F5422CB98B890063FFD1 /* HomePollsCellItem.swift in Sources */,
+				8969F5432CB98B890063FFD1 /* PollOptionCell.swift in Sources */,
+				8969F5442CB98B890063FFD1 /* HomePostCell.swift in Sources */,
+				8969F5452CB98B890063FFD1 /* HomePostCellItem.swift in Sources */,
+				8969F5462CB98B890063FFD1 /* Post.swift in Sources */,
+				8969F5472CB98B890063FFD1 /* HomeFlingCell.swift in Sources */,
+				8969F5482CB98B890063FFD1 /* HomeFlingCellItem.swift in Sources */,
+				8969F5492CB98B890063FFD1 /* HomeUpdateCellItem.swift in Sources */,
+				8969F54A2CB98B890063FFD1 /* HomeCellConformable.swift in Sources */,
+				8969F54B2CB98B890063FFD1 /* HomeCellHeader.swift in Sources */,
+				8969F54C2CB98B890063FFD1 /* HomeCellProtocols.swift in Sources */,
+				8969F54D2CB98B890063FFD1 /* HomeCellSafeArea.swift in Sources */,
+				8969F54E2CB98B890063FFD1 /* BuildingMapWebviewController.swift in Sources */,
+				8969F54F2CB98B890063FFD1 /* DiningCellSettingsController.swift in Sources */,
+				8969F5502CB98B890063FFD1 /* HomeViewController.swift in Sources */,
+				8969F5512CB98B890063FFD1 /* HomeViewController + Delegates.swift in Sources */,
+				8969F5522CB98B890063FFD1 /* HomeCellItem.swift in Sources */,
+				8969F5532CB98B890063FFD1 /* HomeItemTypes.swift in Sources */,
+				8969F5542CB98B890063FFD1 /* HomeTableViewModel.swift in Sources */,
+				8969F5552CB98B890063FFD1 /* HomeAPIService.swift in Sources */,
+				8969F5562CB98B890063FFD1 /* CalendarCardView.swift in Sources */,
+				8969F5572CB98B890063FFD1 /* HomeCardView.swift in Sources */,
+				8969F5582CB98B890063FFD1 /* HomeSublettingBanner.swift in Sources */,
+				8969F5592CB98B890063FFD1 /* HomeView.swift in Sources */,
+				8969F55A2CB98B890063FFD1 /* HomeViewData.swift in Sources */,
+				8969F55B2CB98B890063FFD1 /* HomeViewModel.swift in Sources */,
+				8969F55C2CB98B890063FFD1 /* Model.swift in Sources */,
+				8969F55D2CB98B890063FFD1 /* AddLaundryCell.swift in Sources */,
+				8969F55E2CB98B890063FFD1 /* LaundryCell.swift in Sources */,
+				8969F55F2CB98B890063FFD1 /* LaundryCell + Graph.swift in Sources */,
+				8969F5602CB98B890063FFD1 /* LaundryGraphView.swift in Sources */,
+				8969F5612CB98B890063FFD1 /* LaundryMachineCell.swift in Sources */,
+				8969F5622CB98B890063FFD1 /* LaundryMachinesView.swift in Sources */,
+				8969F5632CB98B890063FFD1 /* LaundryMachineCellTappable.swift in Sources */,
+				8969F5642CB98B890063FFD1 /* LaundryTableViewController.swift in Sources */,
+				8969F5652CB98B890063FFD1 /* RoomSelectionViewController.swift in Sources */,
+				8969F5662CB98B890063FFD1 /* LaundryNotificationCenter.swift in Sources */,
+				8969F5672CB98B890063FFD1 /* LaundryRoom.swift in Sources */,
+				8969F5682CB98B890063FFD1 /* LaundryAPIService.swift in Sources */,
+				8969F5692CB98B890063FFD1 /* RoomSelectionView.swift in Sources */,
+				8969F56A2CB98B890063FFD1 /* Account.swift in Sources */,
+				8969F56B2CB98B890063FFD1 /* AuthManager.swift in Sources */,
+				8969F56C2CB98B890063FFD1 /* CampusExpressLoginController.swift in Sources */,
+				8969F56D2CB98B890063FFD1 /* CampusExpressNetworkManager.swift in Sources */,
+				8969F56E2CB98B890063FFD1 /* Degree.swift in Sources */,
+				8969F56F2CB98B890063FFD1 /* LabsLoginController.swift in Sources */,
+				8969F5702CB98B890063FFD1 /* LabsLoginSwiftUI.swift in Sources */,
+				8969F5712CB98B890063FFD1 /* LoggedOutView.swift in Sources */,
+				8969F5722CB98B890063FFD1 /* PathAtPennNetworkManager.swift in Sources */,
+				8969F5732CB98B890063FFD1 /* PennCashNetworkManager.swift in Sources */,
+				8969F5742CB98B890063FFD1 /* PennInTouchNetworkManager.swift in Sources */,
+				8969F5752CB98B890063FFD1 /* AddressMapView.swift in Sources */,
+				8969F5762CB98B890063FFD1 /* MapViewController.swift in Sources */,
+				8969F5772CB98B890063FFD1 /* PennCoordinate.swift in Sources */,
+				8969F5782CB98B890063FFD1 /* PacCodeNetworkManager.swift in Sources */,
+				8969F5792CB98B890063FFD1 /* PacCodeViewController.swift in Sources */,
+				8969F57A2CB98B890063FFD1 /* ProfilePageNetworkManager.swift in Sources */,
+				8969F57B2CB98B890063FFD1 /* InfoTableViewController.swift in Sources */,
+				8969F57C2CB98B890063FFD1 /* InfoTableViewModel.swift in Sources */,
+				8969F57D2CB98B890063FFD1 /* ProfilePageTableViewCell.swift in Sources */,
+				8969F57E2CB98B890063FFD1 /* ProfilePageViewController.swift in Sources */,
+				8969F57F2CB98B890063FFD1 /* ProfilePageViewModel.swift in Sources */,
+				8969F5802CB98B890063FFD1 /* ProfilePictureTableViewCell.swift in Sources */,
+				8969F5812CB98B890063FFD1 /* AboutViewController.swift in Sources */,
+				8969F5822CB98B890063FFD1 /* HeaderViewCell.swift in Sources */,
+				8969F5832CB98B890063FFD1 /* MoreCell.swift in Sources */,
+				8969F5842CB98B890063FFD1 /* MoreHeaderView.swift in Sources */,
+				8969F5852CB98B890063FFD1 /* MoreView.swift in Sources */,
+				8969F5862CB98B890063FFD1 /* MoreViewController.swift in Sources */,
+				8969F5872CB98B890063FFD1 /* ProfileRowView.swift in Sources */,
+				8969F5882CB98B890063FFD1 /* NewsViewController.swift in Sources */,
+				8969F5892CB98B890063FFD1 /* NotificationAPIModel.swift in Sources */,
+				8969F58A2CB98B890063FFD1 /* NotificationsSetting.swift in Sources */,
+				8969F58B2CB98B890063FFD1 /* NotificationsView.swift in Sources */,
+				8969F58C2CB98B890063FFD1 /* NotificationsViewControllerSwiftUI.swift in Sources */,
+				8969F58D2CB98B890063FFD1 /* NotificationViewModel.swift in Sources */,
+				8969F58E2CB98B890063FFD1 /* NotificationPreference.swift in Sources */,
+				8969F58F2CB98B890063FFD1 /* NotificationRequestable.swift in Sources */,
+				8969F5902CB98B890063FFD1 /* NotificationsTableViewCell.swift in Sources */,
+				8969F5912CB98B890063FFD1 /* NotificationsTableViewController.swift in Sources */,
+				8969F5922CB98B890063FFD1 /* OnboardingController.swift in Sources */,
+				8969F5932CB98B890063FFD1 /* Page.swift in Sources */,
+				8969F5942CB98B890063FFD1 /* PageCell.swift in Sources */,
+				8969F5952CB98B890063FFD1 /* SAConfettiView.swift in Sources */,
+				8969F5962CB98B890063FFD1 /* SelectionCell.swift in Sources */,
+				8969F5972CB98B890063FFD1 /* AIChatModel.swift in Sources */,
+				8969F5982CB98B890063FFD1 /* AIChatView.swift in Sources */,
+				8969F5992CB98B890063FFD1 /* AIChatViewModel.swift in Sources */,
+				8969F59A2CB98B890063FFD1 /* ChatMessage.swift in Sources */,
+				8969F59B2CB98B890063FFD1 /* ChatMessageView.swift in Sources */,
+				8969F59C2CB98B890063FFD1 /* PollQuestion.swift in Sources */,
+				8969F59D2CB98B890063FFD1 /* PollsNetworkManager.swift in Sources */,
+				8969F59E2CB98B890063FFD1 /* PollsView.swift in Sources */,
+				8969F59F2CB98B890063FFD1 /* PollsViewController.swift in Sources */,
+				8969F5A02CB98B890063FFD1 /* PollView.swift in Sources */,
+				8969F5A12CB98B890063FFD1 /* PreferencesView.swift in Sources */,
+				8969F5A22CB98B890063FFD1 /* PreferencesViewController.swift in Sources */,
+				8969F5A32CB98B890063FFD1 /* PermissionView.swift in Sources */,
+				8969F5A42CB98B890063FFD1 /* PrivacyPermissionDelegate.swift in Sources */,
+				8969F5A52CB98B890063FFD1 /* PrivacyPreference.swift in Sources */,
+				8969F5A62CB98B890063FFD1 /* PrivacyTableViewCell.swift in Sources */,
+				8969F5A72CB98B890063FFD1 /* PrivacyTableViewController.swift in Sources */,
+				8969F5A82CB98B890063FFD1 /* AppDelegate.swift in Sources */,
+				8969F5A92CB98B890063FFD1 /* AppDelegate+NotificationExtension.swift in Sources */,
+				8969F5AA2CB98B890063FFD1 /* ControllerModel.swift in Sources */,
+				8969F5AB2CB98B890063FFD1 /* Environment.swift in Sources */,
+				8969F5AC2CB98B890063FFD1 /* Features.swift in Sources */,
+				8969F5AD2CB98B890063FFD1 /* MainTabView.swift in Sources */,
+				8969F5AE2CB98B890063FFD1 /* PennMobile.swift in Sources */,
+				8969F5AF2CB98B890063FFD1 /* RootView.swift in Sources */,
+				8969F5B02CB98B890063FFD1 /* RootViewController.swift in Sources */,
+				8969F5B12CB98B890063FFD1 /* SplashViewController.swift in Sources */,
+				8969F5B22CB98B890063FFD1 /* TabBarController.swift in Sources */,
+				8969F5B32CB98B890063FFD1 /* Toasts.swift in Sources */,
+				8969F5B42CB98B890063FFD1 /* MyListingsActivity.swift in Sources */,
+				8969F5B52CB98B890063FFD1 /* NewListingForm.swift in Sources */,
+				8969F5B62CB98B890063FFD1 /* MarketplaceFilterView.swift in Sources */,
+				8969F5B72CB98B890063FFD1 /* MarketplaceView.swift in Sources */,
+				8969F5B82CB98B890063FFD1 /* SubletCandidatesView.swift in Sources */,
+				8969F5B92CB98B890063FFD1 /* SubletDetailView.swift in Sources */,
+				8969F5BA2CB98B890063FFD1 /* SubletDisplayRow.swift in Sources */,
+				8969F5BB2CB98B890063FFD1 /* SubletInterestForm.swift in Sources */,
+				8969F5BC2CB98B890063FFD1 /* SubletMapView.swift in Sources */,
+				8969F5BD2CB98B890063FFD1 /* SublettingAPI.swift in Sources */,
+				8969F5BE2CB98B890063FFD1 /* SublettingViewModel.swift in Sources */,
 				89EA262E290F9411008F26CF /* Intents.intentdefinition in Sources */,
 				6C369A1526E39BC100721CA1 /* (null) in Sources */,
 				6C23AF9526E57903002F60F0 /* (null) in Sources */,
@@ -609,6 +2818,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8969F2DA2CB98B860063FFD1 /* Course.swift in Sources */,
+				8969F2DB2CB98B860063FFD1 /* ScheduleView.swift in Sources */,
+				8969F2DC2CB98B860063FFD1 /* DiningBalance.swift in Sources */,
+				8969F2DD2CB98B860063FFD1 /* DiningMenu.swift in Sources */,
+				8969F2DE2CB98B860063FFD1 /* DiningPlan.swift in Sources */,
+				8969F2DF2CB98B860063FFD1 /* DiningToken.swift in Sources */,
+				8969F2E02CB98B860063FFD1 /* DiningVenue.swift in Sources */,
+				8969F2E12CB98B860063FFD1 /* DiningVenue+Extensions.swift in Sources */,
+				8969F2E22CB98B860063FFD1 /* PastDiningBalances.swift in Sources */,
+				8969F2E32CB98B860063FFD1 /* DiningAnalyticsViewModel.swift in Sources */,
+				8969F2E42CB98B860063FFD1 /* DiningAPI.swift in Sources */,
+				8969F2E52CB98B860063FFD1 /* DiningVenueRow.swift in Sources */,
+				8969F2E62CB98B860063FFD1 /* FitnessAPI.swift in Sources */,
+				8969F2E72CB98B860063FFD1 /* FitnessGraph.swift in Sources */,
+				8969F2E82CB98B860063FFD1 /* FitnessModel.swift in Sources */,
+				8969F2E92CB98B860063FFD1 /* BadgeView.swift in Sources */,
+				8969F2EA2CB98B860063FFD1 /* Colors.swift in Sources */,
+				8969F2EB2CB98B860063FFD1 /* Day.swift in Sources */,
+				8969F2EC2CB98B860063FFD1 /* Extensions.swift in Sources */,
+				8969F2ED2CB98B860063FFD1 /* KeychainAccessible.swift in Sources */,
+				8969F2EE2CB98B860063FFD1 /* MeterView.swift in Sources */,
+				8969F2EF2CB98B860063FFD1 /* PhoneNumberFormat.swift in Sources */,
+				8969F2F02CB98B860063FFD1 /* SearchBar.swift in Sources */,
+				8969F2F12CB98B860063FFD1 /* SecureStore.swift in Sources */,
+				8969F2F22CB98B860063FFD1 /* Storage.swift in Sources */,
+				8969F2F32CB98B860063FFD1 /* WidgetKind.swift in Sources */,
+				8969F2F42CB98B860063FFD1 /* LaundryAttributes.swift in Sources */,
+				8969F2F52CB98B860063FFD1 /* LaundryMachine.swift in Sources */,
+				8969F2F62CB98B860063FFD1 /* Multipart.swift in Sources */,
+				8969F2F72CB98B860063FFD1 /* NetworkingError.swift in Sources */,
+				8969F2F82CB98B860063FFD1 /* SubletDisplayBox.swift in Sources */,
+				8969F2F92CB98B860063FFD1 /* SublettingModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -616,6 +2857,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8969F5E32CB98B900063FFD1 /* CoursesDayWidget.swift in Sources */,
+				8969F5E42CB98B900063FFD1 /* CoursesProvider.swift in Sources */,
+				8969F5E52CB98B900063FFD1 /* DiningAnalyticsHomeWidget.swift in Sources */,
+				8969F5E62CB98B900063FFD1 /* DiningAnalyticsProvider.swift in Sources */,
+				8969F5E72CB98B900063FFD1 /* DiningHoursProvider.swift in Sources */,
+				8969F5E82CB98B900063FFD1 /* DiningHoursWidget.swift in Sources */,
+				8969F5E92CB98B900063FFD1 /* FitnessProvider.swift in Sources */,
+				8969F5EA2CB98B900063FFD1 /* FitnessWidget.swift in Sources */,
+				8969F5EB2CB98B900063FFD1 /* ConfigurationRepresenting.swift in Sources */,
+				8969F5EC2CB98B900063FFD1 /* LaundryLiveActivity.swift in Sources */,
+				8969F5ED2CB98B900063FFD1 /* ViewExtensions.swift in Sources */,
+				8969F5EE2CB98B900063FFD1 /* WidgetBackgroundTypeExtensions.swift in Sources */,
+				8969F5EF2CB98B900063FFD1 /* WidgetBundle.swift in Sources */,
 				89EA262F290F958B008F26CF /* Intents.intentdefinition in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Hopefully should get CI working again because CocoaPods *still* doesn't support Xcode 16's synchronized folder references: CocoaPods/CocoaPods#12456 
