### PR TITLE
Fix uploading of notification tokens

### DIFF
--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -504,18 +504,37 @@ extension UserDBManager {
 
     // Updates device token.
     func savePushNotificationDeviceToken(deviceToken: String, notifId: Int, _ completion: (() -> Void)? = nil) {
-        let url = "https://pennmobile.org/api/user/notifications/tokens/\(notifId)"
-        var params: [String: Any] = [
-            "kind": "IOS",
-            "token": deviceToken,
-            "dev": false
-        ]
-
-        #if DEBUG
-            params["dev"] = true
-        #endif
-        makePostRequestWithAccessToken(url: url, params: params) { (_, _, _) in
-            completion?()
+        Task {
+            defer { completion?() }
+            
+            struct DeviceTokenRequestBody: Encodable {
+                var kind: String
+                var token: String
+                var dev: Bool
+            }
+            
+            guard let url = URL(string: "https://pennmobile.org/api/user/notifications/tokens/\(notifId)/") else {
+                return
+            }
+            
+            var body = DeviceTokenRequestBody(kind: "IOS", token: deviceToken, dev: false)
+            
+#if DEBUG
+            body.dev = true
+#endif
+            
+            guard let token = await OAuth2NetworkManager.instance.getAccessTokenAsync() else {
+                return
+            }
+            
+            var request = URLRequest(url: url, accessToken: token)
+            request.httpMethod = "PUT"
+            
+            // If serializing a simple JSON object fails something is really wrong
+            request.httpBody = try! JSONEncoder().encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            
+            _ = try? await URLSession.shared.data(for: request)
         }
     }
 

--- a/PennMobile/Notifications/Model/NotificationAPIModel.swift
+++ b/PennMobile/Notifications/Model/NotificationAPIModel.swift
@@ -11,6 +11,5 @@ import Foundation
 struct GetNotificationID: Codable, Identifiable {
     let id: Int
     let kind: String
-    let dev: Bool
     let token: String
 }

--- a/PennMobile/Setup + Navigation/AppDelegate.swift
+++ b/PennMobile/Setup + Navigation/AppDelegate.swift
@@ -17,6 +17,11 @@ import PennMobileShared
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var tabBarController: TabBarController!
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        application.registerForRemoteNotifications()
+        return true
+    }
 
     func application(_ application: UIApplication,
                      didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/PennMobile/Setup + Navigation/PennMobile.swift
+++ b/PennMobile/Setup + Navigation/PennMobile.swift
@@ -29,7 +29,6 @@ struct PennMobile: App {
 
         // Register to receive delegate actions from rich notifications
         UNUserNotificationCenter.current().delegate = delegate
-        UIApplication.shared.registerForRemoteNotifications()
 
         FirebaseApp.configure()
 


### PR DESCRIPTION
Previously, notification tokens weren't being uploaded due to a few issues. This PR fixes them (though itself is insufficient for a robust notification implementation):

* Moves `registerForRemoteNotifications` call into the `AppDelegate`
* Removes `dev` from the DTO for getting a device's notification ID
* Rewrites `savePushNotificationDeviceToken` to send a `PUT` request and append a forward slash to the URL

In the future, we will need additional PRs to support multiple tokens per user, but this is a start.
