### PR TITLE
Rewrite OAuth2NetworkManager as an actor

### DIFF
--- a/PennMobile/Clubs/TicketingAPI.swift
+++ b/PennMobile/Clubs/TicketingAPI.swift
@@ -44,7 +44,7 @@ class TicketingAPI {
     }
     
     func getSession() async throws -> URLSession {
-        guard let accessToken = await OAuth2NetworkManager.instance.getAccessTokenAsync() else {
+        guard let accessToken = try? await OAuth2NetworkManager.instance.getAccessToken() else {
             throw NetworkingError.authenticationError
         }
         

--- a/PennMobile/General/Networking + Analytics/UserDBManager.swift
+++ b/PennMobile/General/Networking + Analytics/UserDBManager.swift
@@ -523,7 +523,7 @@ extension UserDBManager {
             body.dev = true
 #endif
             
-            guard let token = await OAuth2NetworkManager.instance.getAccessTokenAsync() else {
+            guard let token = try? await OAuth2NetworkManager.instance.getAccessToken() else {
                 return
             }
             

--- a/PennMobile/Login/AuthManager.swift
+++ b/PennMobile/Login/AuthManager.swift
@@ -56,9 +56,12 @@ class AuthManager: ObservableObject {
     static func clearAccountData() {
         HTTPCookieStorage.shared.removeCookies(since: Date(timeIntervalSince1970: 0))
         UserDefaults.standard.clearAll()
-        OAuth2NetworkManager.instance.clearRefreshToken()
-        OAuth2NetworkManager.instance.clearCurrentAccessToken()
         Account.clear()
+        
+        Task {
+            await OAuth2NetworkManager.instance.clearRefreshToken()
+            await OAuth2NetworkManager.instance.clearCurrentAccessToken()
+        }
     }
 
     func determineInitialState() {

--- a/PennMobile/Polls/PollsNetworkManager.swift
+++ b/PennMobile/Polls/PollsNetworkManager.swift
@@ -29,7 +29,7 @@ class PollsNetworkManager: NSObject, Requestable, SHA256Hashable {
     let allVotesURL = URL(string: "https://pennmobile.org/api/portal/votes/all/")
     
     func getPollHistory() async -> Result<[PollPost], NetworkingError> {
-        if let token = await OAuth2NetworkManager.instance.getAccessTokenAsync() {
+        if let token = try? await OAuth2NetworkManager.instance.getAccessToken() {
             var request = URLRequest(url: self.allVotesURL!, accessToken: token)
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             let jsonData = try? JSONSerialization.data(withJSONObject: ["id_hash": hash(string: PollsNetworkManager.id, encoding: .base64)])
@@ -51,7 +51,7 @@ class PollsNetworkManager: NSObject, Requestable, SHA256Hashable {
     }
 
     func getActivePolls() async -> Result<[PollQuestion], NetworkingError> {
-        if let token = await OAuth2NetworkManager.instance.getAccessTokenAsync() {
+        if let token = try? await OAuth2NetworkManager.instance.getAccessToken() {
             var request = URLRequest(url: self.pollURL!, accessToken: token)
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             let jsonData = try? JSONSerialization.data(withJSONObject: ["id_hash": hash(string: PollsNetworkManager.id, encoding: .base64)])
@@ -73,7 +73,7 @@ class PollsNetworkManager: NSObject, Requestable, SHA256Hashable {
     }
 
     func getArchivedPolls() async -> Result<[PollQuestion], NetworkingError> {
-        if let token = await OAuth2NetworkManager.instance.getAccessTokenAsync() {
+        if let token = try? await OAuth2NetworkManager.instance.getAccessToken() {
             var request = URLRequest(url: self.recentsURL!, accessToken: token)
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             let jsonData = try? JSONSerialization.data(withJSONObject: ["id_hash": hash(string: PollsNetworkManager.id, encoding: .base64)])
@@ -95,7 +95,7 @@ class PollsNetworkManager: NSObject, Requestable, SHA256Hashable {
     }
 
     func answerPoll(withId id: String, response: Int) async -> Bool {
-        if let token = await OAuth2NetworkManager.instance.getAccessTokenAsync() {
+        if let token = try? await OAuth2NetworkManager.instance.getAccessToken() {
             var request = URLRequest(url: self.votesURL!, accessToken: token)
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             let jsonData = try? JSONSerialization.data(withJSONObject: ["id_hash": hash(string: id, encoding: .base64), "poll_options": [response]] as [String: Any])

--- a/PennMobile/Subletting/SublettingAPI.swift
+++ b/PennMobile/Subletting/SublettingAPI.swift
@@ -44,7 +44,7 @@ public class SublettingAPI {
     public let sublettingUrl = "https://pennmobile.org/api/sublet/properties/"
     
     private func makeSubletRequest<C: Encodable, R: Decodable>(_ urlStr: String? = nil, url: URL? = nil, method: String, isContentJSON: Bool = false, content: C? = nil as String?, returnType: R.Type? = nil as String.Type?) async throws -> R? {
-        guard let accessToken = await OAuth2NetworkManager.instance.getAccessTokenAsync() else {
+        guard let accessToken = try? await OAuth2NetworkManager.instance.getAccessToken() else {
             throw NetworkingError.authenticationError
         }
         
@@ -239,7 +239,7 @@ public class SublettingAPI {
     }
     
     public func uploadSubletImages(images: [UIImage], id: Int, progressHandler: @escaping (Double) -> Void) async throws -> [SubletImage] {
-        guard let accessToken = await OAuth2NetworkManager.instance.getAccessTokenAsync() else {
+        guard let accessToken = try? await OAuth2NetworkManager.instance.getAccessToken() else {
             throw NetworkingError.authenticationError
         }
         


### PR DESCRIPTION
Fully ports `OAuth2NetworkManager` to async/await as a global actor. Also cleans up the logic to hopefully prevent edge cases where users were getting signed out due to overlapping refresh token requests.
