### PR TITLE
Fix Crashlytics script behavior when spaces are in directory names

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -2350,7 +2350,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n${BUILD_DIR%Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILD_DIR%Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Ran into this when I tried moving my derived data folder to an external drive.
