### PR TITLE
Fix home page layout bug for large accessibility text size

### DIFF
--- a/PennMobile/Home/HomeCardView.swift
+++ b/PennMobile/Home/HomeCardView.swift
@@ -73,7 +73,7 @@ struct GenericPostCardView: View {
                 VStack(spacing: 0) {
                     KFImage(imageURL)
                         .resizable()
-                        .scaledToFill()
+                        .scaledToFit()
                     
                     content
                         .background(alignment: .top) {


### PR DESCRIPTION
Fixes this issue:
![IMG_8050](https://github.com/user-attachments/assets/b8756cc0-2c94-4fb9-b185-249f15a37105)
