### PR TITLE
iOS 17

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2018 Penn Labs
+Copyright (c) 2025 Penn Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -2783,7 +2783,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -2839,7 +2839,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -2854,7 +2854,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = navigation;
-				CF_BUNDLE_SHORT_VERSION_STRING = 8.0.10;
+				CF_BUNDLE_LONG_VERSION_STRING = 6700;
+				CF_BUNDLE_SHORT_VERSION_STRING = 8.1.0;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PennMobile/PennMobile.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -2867,12 +2868,12 @@
 				EXCLUDED_ARCHS = "";
 				GCC_PREFIX_HEADER = "";
 				INFOPLIST_FILE = PennMobile/Supporting_Files/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = "$(CF_BUNDLE_SHORT_VERSION_STRING";
+				MARKETING_VERSION = "$(CF_BUNDLE_SHORT_VERSION_STRING)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",
@@ -2895,7 +2896,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = navigation;
-				CF_BUNDLE_SHORT_VERSION_STRING = 8.0.10;
+				CF_BUNDLE_LONG_VERSION_STRING = 6700;
+				CF_BUNDLE_SHORT_VERSION_STRING = 8.1.0;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PennMobile/PennMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -2906,12 +2908,12 @@
 				EXCLUDED_ARCHS = "";
 				GCC_PREFIX_HEADER = "";
 				INFOPLIST_FILE = PennMobile/Supporting_Files/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = "$(CF_BUNDLE_SHORT_VERSION_STRING";
+				MARKETING_VERSION = "$(CF_BUNDLE_SHORT_VERSION_STRING)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -2948,9 +2950,9 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 PennLabs. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 PennLabs. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2996,9 +2998,9 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 PennLabs. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 PennLabs. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3027,7 +3029,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = navigation;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CF_BUNDLE_SHORT_VERSION_STRING = 8.0.10;
+				CF_BUNDLE_LONG_VERSION_STRING = 6700;
+				CF_BUNDLE_SHORT_VERSION_STRING = 8.1.0;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -3042,9 +3045,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Widget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Widget;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 PennLabs. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 PennLabs. All rights reserved.";
 				INTENTS_CODEGEN_LANGUAGE = Automatic;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3070,7 +3073,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = navigation;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CF_BUNDLE_SHORT_VERSION_STRING = 8.0.10;
+				CF_BUNDLE_LONG_VERSION_STRING = 6700;
+				CF_BUNDLE_SHORT_VERSION_STRING = 8.1.0;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -3084,9 +3088,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Widget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Widget;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 PennLabs. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 PennLabs. All rights reserved.";
 				INTENTS_CODEGEN_LANGUAGE = Automatic;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PennMobile/Auth/PennLoginController.swift
+++ b/PennMobile/Auth/PennLoginController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 PennLabs. All rights reserved.
 //
 import Foundation
-import WebKit
+@preconcurrency import WebKit
 import PennMobileShared
 
 class PennLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate {

--- a/PennMobile/Dining/Controllers/DiningLoginController.swift
+++ b/PennMobile/Dining/Controllers/DiningLoginController.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import WebKit
+@preconcurrency import WebKit
 import PennMobileShared
 
 class DiningLoginController: UIViewController, WKUIDelegate, WKNavigationDelegate, SHA256Hashable {

--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
@@ -101,7 +101,7 @@ struct DiningVenueDetailMenuView: View {
                 }
             }
         }
-        .onChange(of: menuDate) { _ in
+        .onChange(of: menuDate) {
             Task.init() {
                 await diningVM.refreshMenus(cache: true, at: menuDate)
                 menus = diningVM.diningMenus[venue.id]?.menus ?? []
@@ -109,7 +109,7 @@ struct DiningVenueDetailMenuView: View {
             }
         }
         
-        .onChange(of: currentMenu) { _ in
+        .onChange(of: currentMenu) {
             print((currentMenu?.service ?? "no menu") + " on " + menuDate.description)
             selectedStation = nil
         }

--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/MenuDisclosureGroup.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/MenuDisclosureGroup.swift
@@ -63,7 +63,7 @@ struct DiningMenuViewHeader: View {
             .onAppear {
                 internalSelection = selectedStation
             }
-            .onChange(of: selectedStation) { _ in
+            .onChange(of: selectedStation) {
                 internalSelection = selectedStation
             }
     }
@@ -87,13 +87,13 @@ struct DiningStationRowStack: View {
                     .background {
                         GeometryReader { proxy in
                             Spacer()
-                                .onChange(of: parentScrollOffset) { _ in
+                                .onChange(of: parentScrollOffset) {
                                     posDictionary.updateValue(proxy.frame(in: .global), forKey: station)
                                 }
                         }
                     }
             }
-            .onChange(of: parentScrollOffset) { _ in
+            .onChange(of: parentScrollOffset) {
                 if (checkDictionary) {
                     /// The most visible element is that which has the highest share of the viewport,
                     /// relative to its own height. If two elements are equally visible, the one whose
@@ -118,7 +118,7 @@ struct DiningStationRowStack: View {
                     }
                 }
             }
-            .onChange(of: currentMenu) { _ in
+            .onChange(of: currentMenu) {
                 posDictionary = [:]
             }
             .onChange(of: selectedStation) { new in

--- a/PennMobile/General/SwiftUI Views/CustomPopupView.swift
+++ b/PennMobile/General/SwiftUI Views/CustomPopupView.swift
@@ -136,7 +136,7 @@ struct CustomPopupView: View {
 }
 
 #Preview {
-    @StateObject var popupManager = PopupManager(
+    @Previewable @StateObject var popupManager = PopupManager(
         title: "Sample title",
         message: "This is a sample message.",
         button1: "See My Listings",

--- a/PennMobile/Home/HomeView.swift
+++ b/PennMobile/Home/HomeView.swift
@@ -35,7 +35,7 @@ struct HomeView<Model: HomeViewModel>: View {
                                 .fontWeight(.bold)
                                 .background(GeometryReader { geometry in
                                     let minY = geometry.frame(in: .global).minY
-                                    Color.clear.onChange(of: minY) { minY in
+                                    Color.clear.onChange(of: minY) {
                                         showTitle = minY <= 16
                                     }
                                 })
@@ -88,8 +88,8 @@ struct HomeView<Model: HomeViewModel>: View {
                     .onAppear {
                         chooseSplashText(data: viewModel.data, for: context.date)
                     }
-                    .onChange(of: context.date) { date in
-                        chooseSplashText(data: viewModel.data, for: date)
+                    .onChange(of: context.date) {
+                        chooseSplashText(data: viewModel.data, for: context.date)
                     }
                 }
             }

--- a/PennMobile/Notifications/SwiftUI/NotificationsView.swift
+++ b/PennMobile/Notifications/SwiftUI/NotificationsView.swift
@@ -23,7 +23,7 @@ struct NotificationsView: View, NotificationRequestable {
                 if NotificationPreference.visibleOptions.contains(setting.service) {
                     Section(footer: Text(setting.service.description)) {
                         Toggle(setting.service.title, isOn: $setting.enabled)
-                            .onChange(of: $setting.enabled.wrappedValue) { value in
+                            .onChange(of: $setting.enabled.wrappedValue) { _, value in
                                 Task.init(operation: { await notificationViewModel.requestChange(service: setting, toValue: value) })
                             }
                     }

--- a/PennMobile/Penn Mobile AI/AIChatView.swift
+++ b/PennMobile/Penn Mobile AI/AIChatView.swift
@@ -47,7 +47,7 @@ struct AIChatView: View {
                                     Spacer()
                                 }.id(msg.id)
                             }
-                        }.onChange(of: vm.thread) { _ in
+                        }.onChange(of: vm.thread) {
                             withAnimation {
                                 proxy.scrollTo(vm.thread.last?.id ?? nil, anchor: .top)
                             }

--- a/PennMobile/Setup + Navigation/MainTabView.swift
+++ b/PennMobile/Setup + Navigation/MainTabView.swift
@@ -63,7 +63,7 @@ struct MainTabView: View {
             .tag("More")
         }
         .id(tabBarFeatures)
-        .onChange(of: navigationManager.currentTab) { _ in
+        .onChange(of: navigationManager.currentTab) {
             navigationManager.resetPath()
         }
         .sheet(isPresented: $navigationManager.isConfiguringTabs) {

--- a/PennMobile/Setup + Navigation/PennMobile.swift
+++ b/PennMobile/Setup + Navigation/PennMobile.swift
@@ -59,7 +59,7 @@ struct PennMobile: App {
             #endif
                 .accentColor(Color("navigation"))
         }
-        .onChange(of: authManager.state.isLoggedIn) { _ in
+        .onChange(of: authManager.state.isLoggedIn) {
             homeViewModel.clearData()
         }
         .onChange(of: authManager.state) { state in

--- a/PennMobileShared/Courses/Course.swift
+++ b/PennMobileShared/Courses/Course.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A time that a course meets.
-public struct MeetingTime: Codable {
+public struct MeetingTime: Codable, Sendable {
     /// Weekday of the meeting time.
     ///
     /// 1 corresponds to Sunday, 7 corresponds to Saturday.
@@ -28,7 +28,7 @@ public struct MeetingTime: Codable {
     }
 }
 
-public struct Course: Codable {
+public struct Course: Codable, Sendable {
     /// Time zone to use in course calculations.
     public static let timezone = TimeZone(identifier: "America/New_York")
 


### PR DESCRIPTION
Based on existing analytics, the Penn Mobile user base does not have many iOS 16 users remaining. Further, many changes to Swift were introduced in iOS 17 to which we don't have access.

**This Pull Request:**

- Bumps minimum iOS Deployment Version to iOS 17 on all modules/targets.
- Bumps version number for CI/CD
- Fixes some deprecation warnings as a result of the new iOS Version (specifically `.onChange()` listeners, which went from one argument to zero or two (old + new) with this iOS version).