### PR TITLE
Make toasts dismissable by swiping them upwards

### DIFF
--- a/PennMobile/Setup + Navigation/RootView.swift
+++ b/PennMobile/Setup + Navigation/RootView.swift
@@ -73,7 +73,6 @@ struct RootView: View {
                                 if shouldEnd {
                                     withAnimation {
                                         self.toast = nil
-                                        toastOffset = 0.0
                                     }
                                 } else {
                                     withAnimation(.snappy) {
@@ -111,10 +110,12 @@ struct RootView: View {
                 if !Task.isCancelled {
                     withAnimation {
                         toast = nil
-                        toastOffset = 0.0
                     }
                 }
             }
+        }
+        .onChange(of: toast?.id) { _ in
+            toastOffset = 0.0
         }
         .onChange(of: scenePhase) { phase in
             if phase == .active && BannerViewModel.isAprilFools {

--- a/PennMobile/Setup + Navigation/RootView.swift
+++ b/PennMobile/Setup + Navigation/RootView.swift
@@ -12,6 +12,7 @@ struct RootView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var bannerViewModel: BannerViewModel
     @State var toast: ToastConfiguration?
+    @State var toastOffset: Double = 0.0
     @StateObject var popupManager = PopupManager()
     @Environment(\.scenePhase) var scenePhase
 
@@ -59,6 +60,28 @@ struct RootView: View {
                 ToastView(configuration: toast)
                     .transition(.opacity.combined(with: .move(edge: .top)))
                     .padding(.top)
+                    .offset(y: toastOffset)
+                    .gesture (
+                        DragGesture()
+                            .onChanged { drag in
+                                // Do not allow the offset to be made positive (go further down the page)
+                                toastOffset = drag.translation.height < 0 ? drag.translation.height : 0
+                            }
+                            .onEnded { drag in
+                                // End behavior calculated based on where the gesture ends (top edge of screen).
+                                let shouldEnd = drag.location.y < 25
+                                if shouldEnd {
+                                    withAnimation {
+                                        self.toast = nil
+                                        toastOffset = 0.0
+                                    }
+                                } else {
+                                    withAnimation(.snappy) {
+                                        toastOffset = 0.0
+                                    }
+                                }
+                            }
+                    )
             }
         }
         .environment(\.presentToast) { configuration in
@@ -88,6 +111,7 @@ struct RootView: View {
                 if !Task.isCancelled {
                     withAnimation {
                         toast = nil
+                        toastOffset = 0.0
                     }
                 }
             }


### PR DESCRIPTION
Toast pop-ups should be dismissable. Given they pop downward from the top of the screen, the natural gesture to dismiss them is (I've seen people do this) swiping them upwards and away.



https://github.com/user-attachments/assets/24336ce8-2086-41ef-8da9-bffee7c97c57