### PR TITLE
Fix GSR State Management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'fastlane', '~> 2.227', '>= 2.227.1'
+gem 'fastlane', '~> 2.227'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  fastlane (~> 2.227, >= 2.227.1)
+  fastlane (~> 2.227)
 
 BUNDLED WITH
    2.6.2

--- a/PennMobile/GSR-Booking/Controllers/GSRController.swift
+++ b/PennMobile/GSR-Booking/Controllers/GSRController.swift
@@ -171,12 +171,13 @@ extension GSRController: GSRViewModelDelegate {
                     switch result {
                     case .success(let rooms):
                         self.viewModel.updateData(with: rooms)
-                        self.refreshDataUI()
-                        self.rangeSlider.reload()
-                        self.refreshBarButton()
                     case .failure:
+                        self.viewModel.updateData(with: [])
                         self.present(toast: .apiError)
                     }
+                    self.refreshDataUI()
+                    self.rangeSlider.reload()
+                    self.refreshBarButton()
                 }
             }
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,7 @@
 #
 
 # Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+# update_fastlane
 
 default_platform(:ios)
 


### PR DESCRIPTION
The GSR rooms array does not reset on a failed request. This leads to us sending a request for a room at a different location than it belongs. This is not validated by anybody, meaning the request is allowed to go through. kudos @ryantanen 

**Before**
https://github.com/user-attachments/assets/dda7bc46-72b0-4583-8a1b-b1c425298ed8

**After**
https://github.com/user-attachments/assets/cb597909-2276-4c0a-afd5-80933c793533

This was done by setting the rooms array to empty when the request fails, then updating the view accordingly.
