### PR TITLE
Performance and usability improvements to redesigned GSR booking flow

### DIFF
--- a/PennMobile/GSR-Booking/Views/GSRLocationCell.swift
+++ b/PennMobile/GSR-Booking/Views/GSRLocationCell.swift
@@ -35,5 +35,6 @@ struct GSRLocationCell: View {
         }
         .frame(height: height)
         .cornerRadius(8)
+        .contentShape(.rect)
     }
 }

--- a/PennMobile/GSR-Booking/Views/GSRTwoWayScrollView.swift
+++ b/PennMobile/GSR-Booking/Views/GSRTwoWayScrollView.swift
@@ -45,7 +45,7 @@ struct GSRTwoWayScrollView: View {
                     HStack(spacing: 0) {
                         Color.clear
                             .frame(width: roomTitleOffset)
-                        VStack(alignment: .center, spacing: 48) {
+                        LazyVStack(alignment: .center, spacing: 48) {
                             ForEach(relevantRooms, id: \.self) { room in
                                 GSRRoomAvailabilityRow(room: room)
                             }
@@ -58,7 +58,7 @@ struct GSRTwoWayScrollView: View {
                         .background {
                             GeometryReader { proxy in
                                 Color.clear
-                                    .onChange(of: proxy.frame(in: .global).midX) { old, new in
+                                    .onChange(of: proxy.frame(in: .scrollView).midX) { old, new in
                                         scrollViewCenterDisplacementValue += new - old
                                     }
                                     .onAppear {
@@ -69,7 +69,7 @@ struct GSRTwoWayScrollView: View {
                     }
                 }
                 .overlay(alignment: .topLeading) {
-                    VStack(alignment: .center, spacing: 48) {
+                    LazyVStack(alignment: .leading, spacing: 48) {
                         ForEach(relevantRooms, id: \.self) { room in
                             Text(room.roomNameShort)
                                 .lineLimit(3)


### PR DESCRIPTION
This PR:

* Makes the entire region of the GSR location row view tappable
* Uses `LazyVStack` views for the GSR grid because using it almost crashed my Vision Pro
* Uses the `.scrollView` coordinate space to position the time header, to avoid layout mismatches when swiping to go back
