### PR TITLE
Fix crash on laundry view

### DIFF
--- a/PennMobile/Laundry/Views/RoomSelectionView.swift
+++ b/PennMobile/Laundry/Views/RoomSelectionView.swift
@@ -33,7 +33,6 @@ class RoomSelectionView: UIView, IndicatorEnabled {
     // Views
     fileprivate var tableView: UITableView = UITableView()
     fileprivate lazy var searchBar = UISearchBar()
-    fileprivate let emptyView: EmptyView = EmptyView().hidden() as! EmptyView
 
     override init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
`RoomSelectionView` instantiated `emptyView`, which resulted in a typecast that always fails. This PR fixes the issue by removing the `emptyView` property entirely.
