### PR TITLE
Revamp localized descriptions for NetworkingError

### DIFF
--- a/PennMobileShared/Networking + Analytics/NetworkingError.swift
+++ b/PennMobileShared/Networking + Analytics/NetworkingError.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2022 PennLabs. All rights reserved.
 //
 
-public enum NetworkingError: LocalizedError {
+public enum NetworkingError: String, LocalizedError {
     case noInternet
     case parsingError
     case serverError
-    case jsonError
-    case authenticationError
-    case alreadyExists
+    case jsonError = "JSON error"
+    case authenticationError = "Unable to authenticate"
+    case alreadyExists = "Offer already exists"
     case other
     
     public var errorDescription: String? {

--- a/PennMobileShared/Networking + Analytics/NetworkingError.swift
+++ b/PennMobileShared/Networking + Analytics/NetworkingError.swift
@@ -14,5 +14,25 @@ public enum NetworkingError: String, Error {
     case authenticationError = "Unable to authenticate"
     case alreadyExists = "Offer already exists"
     case other
-    var localizedDescription: String { self.rawValue }
+    
+    public var localizedDescription: String {
+        let localizationValue: String.LocalizationValue = switch self {
+        case .noInternet:
+            "The Internet connection appears to be offline. Connect to the Internet, then try again."
+        case .parsingError:
+            "The server returned an invalid response. Please report this error."
+        case .serverError:
+            "The operation couldn't be completed due to a server error. Please report this error."
+        case .jsonError:
+            "The server returned a response that didn't match the expected JSON format. Please report this error."
+        case .authenticationError:
+            "There was an authentication error. Try signing out, then signing in again."
+        case .alreadyExists:
+            "This offer already exists."
+        case .other:
+            "An unknown networking error occurred. Please report this error."
+        }
+        
+        return String(localized: localizationValue)
+    }
 }

--- a/PennMobileShared/Networking + Analytics/NetworkingError.swift
+++ b/PennMobileShared/Networking + Analytics/NetworkingError.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 PennLabs. All rights reserved.
 //
 
-public enum NetworkingError: String, Error {
+public enum NetworkingError: String, LocalizedError {
     case noInternet
     case parsingError
     case serverError
@@ -15,7 +15,7 @@ public enum NetworkingError: String, Error {
     case alreadyExists = "Offer already exists"
     case other
     
-    public var localizedDescription: String {
+    public var errorDescription: String? {
         let localizationValue: String.LocalizationValue = switch self {
         case .noInternet:
             "The Internet connection appears to be offline. Connect to the Internet, then try again."

--- a/PennMobileShared/Networking + Analytics/NetworkingError.swift
+++ b/PennMobileShared/Networking + Analytics/NetworkingError.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2022 PennLabs. All rights reserved.
 //
 
-public enum NetworkingError: String, LocalizedError {
+public enum NetworkingError: LocalizedError {
     case noInternet
     case parsingError
     case serverError
-    case jsonError = "JSON error"
-    case authenticationError = "Unable to authenticate"
-    case alreadyExists = "Offer already exists"
+    case jsonError
+    case authenticationError
+    case alreadyExists
     case other
     
     public var errorDescription: String? {


### PR DESCRIPTION
Previously, any thrown `NetworkingError`s were displayed with a generic error message:

> The operation couldn't be completed. (PennMobileShared.NetworkingError error 2.).

This PR fixes that by declaring conformance to `LocalizedError`, and adds some more user-friendly error messages to boot.
