### PR TITLE
Remove the subletting banner

### DIFF
--- a/PennMobile/Home/HomeViewModel.swift
+++ b/PennMobile/Home/HomeViewModel.swift
@@ -40,7 +40,7 @@ extension Optional {
     }
     
     func populateSublettingBannerData() {
-        data.showSublettingBanner = !UserDefaults.standard.bool(forKey: Self.sublettingBannerKey)
+        // data.showSublettingBanner = !UserDefaults.standard.bool(forKey: Self.sublettingBannerKey)
         data.onStartSubletting = { [weak self] in
             if let self, let navigationManager {
                 let tabFeatures = UserDefaults.standard.getTabBarFeatureIdentifiers()


### PR DESCRIPTION
People are probably not looking for housing, so it makes sense to remove this for now to prioritize Portal posts.

In the future, we can consider reinstating this, either with some additional logic or by re-implementing it as a Portal post (although this may change with Marketplace coming soon.)
