### PR TITLE
Tweak CI to reduce usage and allow downloading of artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - 'main'
+  pull_request:
   workflow_dispatch:
 jobs:
   build:
@@ -85,6 +88,7 @@ jobs:
         with:
           name: build
           path: PennMobile.ipa
+          retention-days: 14
   upload:
     needs: build
     if: github.ref == 'refs/heads/main'
@@ -111,12 +115,3 @@ jobs:
           name: build
       - name: Upload to TestFlight
         run: bundle exec fastlane ci_pilot
-  cleanup:
-    runs-on: macos-15
-    needs: [build, upload]
-    if: always()
-    steps:
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,9 +30,9 @@ platform :ios do
 
   lane :ci_build do
     ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
-    increment_build_number({
-      build_number: latest_testflight_build_number(api_key_path: "api_key.json", app_identifier: "org.pennlabs.PennMobile") + 1
-    })
+    increment_build_number(
+      build_number: Time.now.getutc.strftime("%Y%m%d.%H%M%S")
+    )
     
     build_app(
         scheme: "PennMobile",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,8 +30,17 @@ platform :ios do
 
   lane :ci_build do
     ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
+    # Use Philadelphia's timezone (America/New_York) for build number: YYYYMMDD.HHMMSS
+    previous_tz = ENV['TZ']
+    begin
+      ENV['TZ'] = 'America/New_York'
+      date_build_number = Time.now.strftime("%Y%m%d.%H%M%S")
+    ensure
+      ENV['TZ'] = previous_tz
+    end
+
     increment_build_number(
-      build_number: Time.now.getutc.strftime("%Y%m%d.%H%M%S")
+      build_number: date_build_number
     )
     
     build_app(


### PR DESCRIPTION
This makes a number of tweaks to our CI/CD workflow, in particular:
* Limits our workflow to run only on pushes to `main`, on PR updates, or via manual dispatch
* Removes the `cleanup` step so we can download artifacts after the fact
* Adds a 14-day retention period for artifacts
* Changes the build numbering scheme to a date-based one (YYYYMMDD.HHMMSS)

The intended effect is two-fold:
1. It will reduce credit usage by not running CI for experimental branches or branches without a PR
2. It will allow us to release hotfixes by downloading the artifact and uploading the .ipa manually to App Store Connect
3. It will prevent most build number conflicts by using a stateless approach

(Storing artifacts will result in increased storage costs, though this should be offset by limiting the range of possible triggers.)