### PR TITLE
Switch CI to Xcode 26 RC / iOS 26 SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Select Xcode 26.0 RC
         # This could be the source of error for versioning issues in CI.


### PR DESCRIPTION
This PR switches our CI to the (as of now upcoming) Xcode 26 release candidate, allowing us to use features introduced in iOS 26, such as Liquid Glass, and submit apps with them.

~~Chances are it won't roll out to our CI image until mid next week (around when iOS 26 itself releases), so we should hold off on merging this until then.~~

Any PRs relying on iOS 26 features should use this as their base branch.