### PR TITLE
Change "Closed For Today" message to "No Menu Data"

### DIFF
--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
@@ -85,7 +85,7 @@ struct DiningVenueDetailMenuView: View {
                         }
                     }.pickerStyle(MenuPickerStyle())
                 } else {
-                    Text("Closed For Today")
+                    Text("No Menu Data")
                 }
                 DatePicker("", selection: $menuDate, in: Date.currentLocalDate...Date.currentLocalDate.add(minutes: 8640), displayedComponents: .date)
                 


### PR DESCRIPTION
This change should make what's happening more clear to users should dining menus break in the future.
