### PR TITLE
Feature flag GSR Quick Book

### DIFF
--- a/PennMobile/GSR-Booking/Views/GSRBookingToolbarView.swift
+++ b/PennMobile/GSR-Booking/Views/GSRBookingToolbarView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import PennMobileShared
 
 struct GSRBookingToolbarView: View {
     @EnvironmentObject var vm: GSRViewModel
@@ -67,7 +68,7 @@ struct GSRBookingToolbarView: View {
                                 }
                         }
                         .transition(.move(edge: .leading).combined(with: .opacity))
-                    } else {
+                    } else if FeatureFlags.shared.gsrQuickBook {
                         RoomFinderSelectionPanel(isEnabled: $startedQuickBook)
                             .transition(.move(edge: .leading).combined(with: .opacity))
                     }

--- a/PennMobileShared/Feature Flags/FeatureFlags.swift
+++ b/PennMobileShared/Feature Flags/FeatureFlags.swift
@@ -16,6 +16,8 @@ public class FeatureFlags {
     @FeatureFlagDefinition("ALWAYS_SHOW_FEATURE_FLAG_SETTINGS", channel: .testFlight) public var alwaysShowFeatureFlagSettings
     @FeatureFlagDefinition("TEST_FEATURE_FLAG", channel: .adHoc) public var testFeatureFlag
     
+    @FeatureFlagDefinition("GSR_QUICK_BOOK", channel: .testFlight) public var gsrQuickBook
+    
     @MainActor public var showFeatureFlagSettings: Bool {
         if RolloutChannel.current >= .testFlight || alwaysShowFeatureFlagSettings || RolloutChannel.override != nil {
             return true


### PR DESCRIPTION
This feature flags the quick book feature to TestFlight-only by default so that we can have more time to polish things up. 
