### PR TITLE
Remove force unwrapping of currentMenu Binding

### DIFF
--- a/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
+++ b/PennMobile/Dining/SwiftUI/Views/Venue/Detail View/DiningVenueDetailMenuView.swift
@@ -79,9 +79,10 @@ struct DiningVenueDetailMenuView: View {
         LazyVStack(pinnedViews: [.sectionHeaders]) {
             HStack {
                 if currentMenu != nil {
-                    Picker("Menu", selection: Binding($currentMenu)!) {
+                    Picker("Menu", selection: $currentMenu) {
                         ForEach(menus, id: \.self) { menu in
                             Text(menu.service)
+                                .tag(menu)
                         }
                     }.pickerStyle(MenuPickerStyle())
                 } else {


### PR DESCRIPTION
Should fix a recurring crash we've been seeing. Affected crash reports usually display something like this:

> SwiftUICore: BindingOperations.ForceUnwrapping.get(base:) + 308

I'm guessing this is because projected Bindings probably aren't perfectly synced with their underlying values? Either way, I suppose this is your daily reminder to not force unwrap things unless absolutely necessary lol
