### PR TITLE
Fix Auth Stability Issues & bump LabsPlatformSwift version

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -23,8 +23,9 @@
 		6E5159F32AC8CA1B004B3F41 /* PennMobileShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E4D82162AC8C91C009AB78E /* PennMobileShared.framework */; };
 		6E5159F92AC8D88A004B3F41 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 6E5159F82AC8D88A004B3F41 /* SwiftyJSON */; };
 		6ECB4C2D2ACA6F7600F7379A /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 6ECB4C2C2ACA6F7600F7379A /* Kingfisher */; };
-		732CE8CF2EB56ED7004903F2 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 732CE8CE2EB56ED7004903F2 /* LabsPlatformSwift */; };
+		731A45F32F4D0CE30078DEB8 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 731A45F22F4D0CE30078DEB8 /* LabsPlatformSwift */; };
 		734BED9B2D9DE4B700964811 /* PennForms in Frameworks */ = {isa = PBXBuildFile; productRef = 734BED9A2D9DE4B700964811 /* PennForms */; };
+		735727032F4CE1B200213ACA /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 735727022F4CE1B200213ACA /* LabsPlatformSwift */; };
 		73E7A02C2CF158F3007BC1E3 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 73E7A02B2CF158F3007BC1E3 /* Lottie */; };
 		8932693528FC75A5003D4BF9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693428FC75A5003D4BF9 /* WidgetKit.framework */; };
 		8932693728FC75A5003D4BF9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693628FC75A5003D4BF9 /* SwiftUI.framework */; };
@@ -170,7 +171,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				732CE8CF2EB56ED7004903F2 /* LabsPlatformSwift in Frameworks */,
+				735727032F4CE1B200213ACA /* LabsPlatformSwift in Frameworks */,
 				42AC0CC52DC7D8A20060DD5E /* ActivityKit.framework in Frameworks */,
 				42AC0CC52DC7D8A20060DD5E /* ActivityKit.framework in Frameworks */,
 				6CE12F9026E82DC600284D9F /* FirebaseAnalytics in Frameworks */,
@@ -183,6 +184,7 @@
 				895A1ABB2CB98F7100E161AE /* SCLAlertView in Frameworks */,
 				F213CCE223C3EE3E000AD90F /* SwiftSoup in Frameworks */,
 				6E4D821C2AC8C91C009AB78E /* PennMobileShared.framework in Frameworks */,
+				731A45F32F4D0CE30078DEB8 /* LabsPlatformSwift in Frameworks */,
 				895A1AB52CB98E9000E161AE /* XLPagerTabStrip in Frameworks */,
 				895A1AB82CB98F5000E161AE /* ScrollableGraphView in Frameworks */,
 				73E7A02C2CF158F3007BC1E3 /* Lottie in Frameworks */,
@@ -354,7 +356,8 @@
 				734BED9A2D9DE4B700964811 /* PennForms */,
 				73E7A02B2CF158F3007BC1E3 /* Lottie */,
 				734BED9A2D9DE4B700964811 /* PennForms */,
-				732CE8CE2EB56ED7004903F2 /* LabsPlatformSwift */,
+				735727022F4CE1B200213ACA /* LabsPlatformSwift */,
+				731A45F22F4D0CE30078DEB8 /* LabsPlatformSwift */,
 			);
 			productName = PennMobile;
 			productReference = 216640601EBADADA00746B8E /* PennMobile.app */;
@@ -463,7 +466,7 @@
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
 				73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
-				732CE8CD2EB56ED7004903F2 /* XCRemoteSwiftPackageReference "labs-platform-swift" */,
+				731A45F12F4D0CE30078DEB8 /* XCRemoteSwiftPackageReference "labs-platform-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 216640611EBADADA00746B8E /* Products */;
@@ -1009,12 +1012,12 @@
 				minimumVersion = 10.0.0;
 			};
 		};
-		732CE8CD2EB56ED7004903F2 /* XCRemoteSwiftPackageReference "labs-platform-swift" */ = {
+		731A45F12F4D0CE30078DEB8 /* XCRemoteSwiftPackageReference "labs-platform-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pennlabs/labs-platform-swift";
 			requirement = {
-				kind = revision;
-				revision = d423a91746ddc5e05c0ebc210767450da576525e;
+				branch = "jon0/auth-stability-swift-data";
+				kind = branch;
 			};
 		};
 		734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */ = {
@@ -1119,15 +1122,19 @@
 			package = F213CCE323C3F240000AD90F /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
-		732CE8CE2EB56ED7004903F2 /* LabsPlatformSwift */ = {
+		731A45F22F4D0CE30078DEB8 /* LabsPlatformSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 732CE8CD2EB56ED7004903F2 /* XCRemoteSwiftPackageReference "labs-platform-swift" */;
+			package = 731A45F12F4D0CE30078DEB8 /* XCRemoteSwiftPackageReference "labs-platform-swift" */;
 			productName = LabsPlatformSwift;
 		};
 		734BED9A2D9DE4B700964811 /* PennForms */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */;
 			productName = PennForms;
+		};
+		735727022F4CE1B200213ACA /* LabsPlatformSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LabsPlatformSwift;
 		};
 		73E7A02B2CF158F3007BC1E3 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -23,8 +23,9 @@
 		6E5159F32AC8CA1B004B3F41 /* PennMobileShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E4D82162AC8C91C009AB78E /* PennMobileShared.framework */; };
 		6E5159F92AC8D88A004B3F41 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 6E5159F82AC8D88A004B3F41 /* SwiftyJSON */; };
 		6ECB4C2D2ACA6F7600F7379A /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 6ECB4C2C2ACA6F7600F7379A /* Kingfisher */; };
-		731A45F32F4D0CE30078DEB8 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 731A45F22F4D0CE30078DEB8 /* LabsPlatformSwift */; };
+		7348F0502F807CEB002901E4 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7348F04F2F807CEB002901E4 /* LabsPlatformSwift */; };
 		734BED9B2D9DE4B700964811 /* PennForms in Frameworks */ = {isa = PBXBuildFile; productRef = 734BED9A2D9DE4B700964811 /* PennForms */; };
+		7353066A2F82AE1700299200 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 735306692F82AE1700299200 /* LabsPlatformSwift */; };
 		735727032F4CE1B200213ACA /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 735727022F4CE1B200213ACA /* LabsPlatformSwift */; };
 		73E7A02C2CF158F3007BC1E3 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 73E7A02B2CF158F3007BC1E3 /* Lottie */; };
 		8932693528FC75A5003D4BF9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693428FC75A5003D4BF9 /* WidgetKit.framework */; };
@@ -191,12 +192,13 @@
 				734BED9B2D9DE4B700964811 /* PennForms in Frameworks */,
 				734BED9B2D9DE4B700964811 /* PennForms in Frameworks */,
 				6CA1ACDB271D2D5000EDB967 /* Kingfisher in Frameworks */,
+				7353066A2F82AE1700299200 /* LabsPlatformSwift in Frameworks */,
 				6C4CC1FA26E6B1720000B4A8 /* SwiftyJSON in Frameworks */,
 				6CE12F9226E82DC600284D9F /* FirebaseCrashlytics in Frameworks */,
 				895A1ABB2CB98F7100E161AE /* SCLAlertView in Frameworks */,
 				F213CCE223C3EE3E000AD90F /* SwiftSoup in Frameworks */,
 				6E4D821C2AC8C91C009AB78E /* PennMobileShared.framework in Frameworks */,
-				731A45F32F4D0CE30078DEB8 /* LabsPlatformSwift in Frameworks */,
+				7348F0502F807CEB002901E4 /* LabsPlatformSwift in Frameworks */,
 				895A1AB52CB98E9000E161AE /* XLPagerTabStrip in Frameworks */,
 				895A1AB82CB98F5000E161AE /* ScrollableGraphView in Frameworks */,
 				73E7A02C2CF158F3007BC1E3 /* Lottie in Frameworks */,
@@ -369,7 +371,8 @@
 				73E7A02B2CF158F3007BC1E3 /* Lottie */,
 				734BED9A2D9DE4B700964811 /* PennForms */,
 				735727022F4CE1B200213ACA /* LabsPlatformSwift */,
-				731A45F22F4D0CE30078DEB8 /* LabsPlatformSwift */,
+				7348F04F2F807CEB002901E4 /* LabsPlatformSwift */,
+				735306692F82AE1700299200 /* LabsPlatformSwift */,
 			);
 			productName = PennMobile;
 			productReference = 216640601EBADADA00746B8E /* PennMobile.app */;
@@ -478,7 +481,7 @@
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
 				73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
-				731A45F12F4D0CE30078DEB8 /* XCRemoteSwiftPackageReference "labs-platform-swift" */,
+				735306682F82AE1700299200 /* XCRemoteSwiftPackageReference "labs-platform-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 216640611EBADADA00746B8E /* Products */;
@@ -1024,20 +1027,20 @@
 				minimumVersion = 10.0.0;
 			};
 		};
-		731A45F12F4D0CE30078DEB8 /* XCRemoteSwiftPackageReference "labs-platform-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pennlabs/labs-platform-swift";
-			requirement = {
-				branch = "jon0/auth-stability-swift-data";
-				kind = branch;
-			};
-		};
 		734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pennlabs/PennForms";
 			requirement = {
 				branch = main;
 				kind = branch;
+			};
+		};
+		735306682F82AE1700299200 /* XCRemoteSwiftPackageReference "labs-platform-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pennlabs/labs-platform-swift";
+			requirement = {
+				kind = revision;
+				revision = e09205b69961ee8390c792ba7ecbf547f7f93ce4;
 			};
 		};
 		73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
@@ -1134,15 +1137,19 @@
 			package = F213CCE323C3F240000AD90F /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
-		731A45F22F4D0CE30078DEB8 /* LabsPlatformSwift */ = {
+		7348F04F2F807CEB002901E4 /* LabsPlatformSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 731A45F12F4D0CE30078DEB8 /* XCRemoteSwiftPackageReference "labs-platform-swift" */;
 			productName = LabsPlatformSwift;
 		};
 		734BED9A2D9DE4B700964811 /* PennForms */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */;
 			productName = PennForms;
+		};
+		735306692F82AE1700299200 /* LabsPlatformSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 735306682F82AE1700299200 /* XCRemoteSwiftPackageReference "labs-platform-swift" */;
+			productName = LabsPlatformSwift;
 		};
 		735727022F4CE1B200213ACA /* LabsPlatformSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PennMobile/General/UserDefaults + Helpers.swift
+++ b/PennMobile/General/UserDefaults + Helpers.swift
@@ -289,7 +289,6 @@ extension UserDefaults {
 extension UserDefaults {
     func setLastLogin() {
         set(Date(), forKey: UserDefaultsKeys.lastLogin.rawValue)
-        synchronize()
     }
 
     func getLastLogin() -> Date? {

--- a/PennMobile/Home/HomeView.swift
+++ b/PennMobile/Home/HomeView.swift
@@ -108,6 +108,7 @@ struct HomeView<Model: HomeViewModel>: View {
                 try? await viewModel.fetchData(force: false)
             }
         }
+        
     }
     
     func chooseSplashText(data: HomeViewData, for date: Date) {

--- a/PennMobile/LaundryPrototype/Services/LaundryAlarmService.swift
+++ b/PennMobile/LaundryPrototype/Services/LaundryAlarmService.swift
@@ -30,10 +30,10 @@ enum LaundryAlarmService {
                 return FallbackAlarmHandler()
             }
             
-            if #available(iOS 26.1, *), ProcessInfo.processInfo.isiOSAppOnVision {
-                // you're welcome anthony
-                return FallbackAlarmHandler()
-            }
+//            if #available(iOS 26.1, *), ProcessInfo.processInfo.isiOSAppOnVision {
+//                // you're welcome anthony
+//                return FallbackAlarmHandler()
+//            }
             
             return AlarmKitAlarmHandler()
         }

--- a/PennMobile/Login/LoggedOutView.swift
+++ b/PennMobile/Login/LoggedOutView.swift
@@ -12,7 +12,6 @@ import LabsPlatformSwift
 struct LoggedOutView: View {
     @EnvironmentObject var authManager: AuthManager
     @Environment(\.colorScheme) var colorScheme
-    let platform = LabsPlatform.shared
 
     var body: some View {
         VStack(spacing: 90) {

--- a/PennMobile/Setup + Navigation/PennMobile.swift
+++ b/PennMobile/Setup + Navigation/PennMobile.swift
@@ -33,9 +33,7 @@ struct PennMobile: App {
         #endif
         
         let authManager = AuthManager()
-        authManager.determineInitialState()
         let state = authManager.state
-        
         self._authManager = StateObject(wrappedValue: authManager)
 
         // Register to receive delegate actions from rich notifications


### PR DESCRIPTION
With https://github.com/pennlabs/labs-platform-swift/pull/6 a bump is required.

Other changes (some, not all, required from the aforementioned bump):

- Supporting a synchronous initial login state check to allow login logic to take place before anything else.
- Initialize AuthManager state prior to main thread establishment to prevent weird UX with the login screen flashing first (when a refresh flow is required). Required a change to `determineInitialState` (see below)
- Force-fetching the home view model on login change (caused the home page to load correctly on first login without requiring a manual refresh)
- `determineInitialState` has been modified to instead make state changes w.r.t. auth state more explicit. Now called `getInitialState`, where changes to AuthManager.authState are explicitly declared. (immutable functions >>>>)