### PR TITLE
Move auth to WebAuthenticationSession

### DIFF
--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -25,8 +25,8 @@
 		6ECB4C2D2ACA6F7600F7379A /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 6ECB4C2C2ACA6F7600F7379A /* Kingfisher */; };
 		7348F0502F807CEB002901E4 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7348F04F2F807CEB002901E4 /* LabsPlatformSwift */; };
 		734BED9B2D9DE4B700964811 /* PennForms in Frameworks */ = {isa = PBXBuildFile; productRef = 734BED9A2D9DE4B700964811 /* PennForms */; };
-		7353066A2F82AE1700299200 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 735306692F82AE1700299200 /* LabsPlatformSwift */; };
 		735727032F4CE1B200213ACA /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 735727022F4CE1B200213ACA /* LabsPlatformSwift */; };
+		737F2B27304A244C0093F7A0 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 737F2B26304A244C0093F7A0 /* LabsPlatformSwift */; };
 		73E7A02C2CF158F3007BC1E3 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 73E7A02B2CF158F3007BC1E3 /* Lottie */; };
 		8932693528FC75A5003D4BF9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693428FC75A5003D4BF9 /* WidgetKit.framework */; };
 		8932693728FC75A5003D4BF9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693628FC75A5003D4BF9 /* SwiftUI.framework */; };
@@ -192,7 +192,7 @@
 				734BED9B2D9DE4B700964811 /* PennForms in Frameworks */,
 				734BED9B2D9DE4B700964811 /* PennForms in Frameworks */,
 				6CA1ACDB271D2D5000EDB967 /* Kingfisher in Frameworks */,
-				7353066A2F82AE1700299200 /* LabsPlatformSwift in Frameworks */,
+				737F2B27304A244C0093F7A0 /* LabsPlatformSwift in Frameworks */,
 				6C4CC1FA26E6B1720000B4A8 /* SwiftyJSON in Frameworks */,
 				6CE12F9226E82DC600284D9F /* FirebaseCrashlytics in Frameworks */,
 				895A1ABB2CB98F7100E161AE /* SCLAlertView in Frameworks */,
@@ -372,7 +372,7 @@
 				734BED9A2D9DE4B700964811 /* PennForms */,
 				735727022F4CE1B200213ACA /* LabsPlatformSwift */,
 				7348F04F2F807CEB002901E4 /* LabsPlatformSwift */,
-				735306692F82AE1700299200 /* LabsPlatformSwift */,
+				737F2B26304A244C0093F7A0 /* LabsPlatformSwift */,
 			);
 			productName = PennMobile;
 			productReference = 216640601EBADADA00746B8E /* PennMobile.app */;
@@ -481,7 +481,7 @@
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
 				73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
-				735306682F82AE1700299200 /* XCRemoteSwiftPackageReference "labs-platform-swift" */,
+				737F2B25304A244B0093F7A0 /* XCLocalSwiftPackageReference "../LabsPlatformSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 216640611EBADADA00746B8E /* Products */;
@@ -727,7 +727,7 @@
 				EXCLUDED_ARCHS = "";
 				GCC_PREFIX_HEADER = "";
 				INFOPLIST_FILE = PennMobile/Supporting_Files/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -767,7 +767,7 @@
 				EXCLUDED_ARCHS = "";
 				GCC_PREFIX_HEADER = "";
 				INFOPLIST_FILE = PennMobile/Supporting_Files/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1011,6 +1011,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		737F2B25304A244B0093F7A0 /* XCLocalSwiftPackageReference "../LabsPlatformSwift" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../LabsPlatformSwift;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		6C4CC1F826E6B1720000B4A8 /* XCRemoteSwiftPackageReference "SwiftyJSON" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1034,14 +1041,6 @@
 			requirement = {
 				branch = main;
 				kind = branch;
-			};
-		};
-		735306682F82AE1700299200 /* XCRemoteSwiftPackageReference "labs-platform-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pennlabs/labs-platform-swift";
-			requirement = {
-				kind = revision;
-				revision = 4b3d9c78566534834dc9f8b59b658d37777067f4;
 			};
 		};
 		73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
@@ -1147,12 +1146,11 @@
 			package = 734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */;
 			productName = PennForms;
 		};
-		735306692F82AE1700299200 /* LabsPlatformSwift */ = {
+		735727022F4CE1B200213ACA /* LabsPlatformSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 735306682F82AE1700299200 /* XCRemoteSwiftPackageReference "labs-platform-swift" */;
 			productName = LabsPlatformSwift;
 		};
-		735727022F4CE1B200213ACA /* LabsPlatformSwift */ = {
+		737F2B26304A244C0093F7A0 /* LabsPlatformSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LabsPlatformSwift;
 		};

--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -1043,8 +1043,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pennlabs/labs-platform-swift";
 			requirement = {
-				branch = jon0/ASWeb;
-				kind = branch;
+				kind = exactVersion;
+				version = 1.2.0;
 			};
 		};
 		73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/PennMobile.xcodeproj/project.pbxproj
+++ b/PennMobile.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		734BED9B2D9DE4B700964811 /* PennForms in Frameworks */ = {isa = PBXBuildFile; productRef = 734BED9A2D9DE4B700964811 /* PennForms */; };
 		735727032F4CE1B200213ACA /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 735727022F4CE1B200213ACA /* LabsPlatformSwift */; };
 		737F2B27304A244C0093F7A0 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 737F2B26304A244C0093F7A0 /* LabsPlatformSwift */; };
+		737F2B2A304A38800093F7A0 /* LabsPlatformSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 737F2B29304A38800093F7A0 /* LabsPlatformSwift */; };
 		73E7A02C2CF158F3007BC1E3 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 73E7A02B2CF158F3007BC1E3 /* Lottie */; };
 		8932693528FC75A5003D4BF9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693428FC75A5003D4BF9 /* WidgetKit.framework */; };
 		8932693728FC75A5003D4BF9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8932693628FC75A5003D4BF9 /* SwiftUI.framework */; };
@@ -197,6 +198,7 @@
 				6CE12F9226E82DC600284D9F /* FirebaseCrashlytics in Frameworks */,
 				895A1ABB2CB98F7100E161AE /* SCLAlertView in Frameworks */,
 				F213CCE223C3EE3E000AD90F /* SwiftSoup in Frameworks */,
+				737F2B2A304A38800093F7A0 /* LabsPlatformSwift in Frameworks */,
 				6E4D821C2AC8C91C009AB78E /* PennMobileShared.framework in Frameworks */,
 				7348F0502F807CEB002901E4 /* LabsPlatformSwift in Frameworks */,
 				895A1AB52CB98E9000E161AE /* XLPagerTabStrip in Frameworks */,
@@ -373,6 +375,7 @@
 				735727022F4CE1B200213ACA /* LabsPlatformSwift */,
 				7348F04F2F807CEB002901E4 /* LabsPlatformSwift */,
 				737F2B26304A244C0093F7A0 /* LabsPlatformSwift */,
+				737F2B29304A38800093F7A0 /* LabsPlatformSwift */,
 			);
 			productName = PennMobile;
 			productReference = 216640601EBADADA00746B8E /* PennMobile.app */;
@@ -481,7 +484,7 @@
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
 				73E7A02A2CF158F3007BC1E3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				734BED992D9DE4B700964811 /* XCRemoteSwiftPackageReference "PennForms" */,
-				737F2B25304A244B0093F7A0 /* XCLocalSwiftPackageReference "../LabsPlatformSwift" */,
+				737F2B28304A387F0093F7A0 /* XCRemoteSwiftPackageReference "labs-platform-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 216640611EBADADA00746B8E /* Products */;
@@ -1011,13 +1014,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		737F2B25304A244B0093F7A0 /* XCLocalSwiftPackageReference "../LabsPlatformSwift" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../LabsPlatformSwift;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		6C4CC1F826E6B1720000B4A8 /* XCRemoteSwiftPackageReference "SwiftyJSON" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1040,6 +1036,14 @@
 			repositoryURL = "https://github.com/pennlabs/PennForms";
 			requirement = {
 				branch = main;
+				kind = branch;
+			};
+		};
+		737F2B28304A387F0093F7A0 /* XCRemoteSwiftPackageReference "labs-platform-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pennlabs/labs-platform-swift";
+			requirement = {
+				branch = jon0/ASWeb;
 				kind = branch;
 			};
 		};
@@ -1152,6 +1156,11 @@
 		};
 		737F2B26304A244C0093F7A0 /* LabsPlatformSwift */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = LabsPlatformSwift;
+		};
+		737F2B29304A38800093F7A0 /* LabsPlatformSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 737F2B28304A387F0093F7A0 /* XCRemoteSwiftPackageReference "labs-platform-swift" */;
 			productName = LabsPlatformSwift;
 		};
 		73E7A02B2CF158F3007BC1E3 /* Lottie */ = {

--- a/PennMobile/Setup + Navigation/PennMobile.swift
+++ b/PennMobile/Setup + Navigation/PennMobile.swift
@@ -68,7 +68,7 @@ struct PennMobile: App {
                 .accentColor(Color("navigation"))
                 .enableLabsPlatform(analyticsRoot: "pennmobile",
                                     clientId: InfoPlistEnvironment.labsOauthClientId,
-                                    redirectUrl: "https://pennlabs.org/pennmobile/ios/callback/",
+                                    redirectUrl: "pennmobile://auth",
                                     defaultLoginHandler: authManager.handlePlatformDefaultLogin,
                                     authManager.handlePlatformLogin)
         }

--- a/PennMobile/Supporting_Files/Info.plist
+++ b/PennMobile/Supporting_Files/Info.plist
@@ -41,7 +41,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAlarmKitUsageDescription</key>
-	<string>We'll schedule alerts for laundry machines you subscribe to in the app.</string>
+	<string>We&apos;ll schedule alerts for laundry machines you subscribe to in the app.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
Move to WebAuthenticationSession as the web backbone for main authentication. This leads to a better and more stable user experience.

See https://github.com/pennlabs/labs-platform-swift/pull/7