### PR TITLE
Fix dining analytics edge case

### DIFF
--- a/PennMobileShared/Dining/DiningAnalyticsViewModel.swift
+++ b/PennMobileShared/Dining/DiningAnalyticsViewModel.swift
@@ -175,7 +175,7 @@ public class DiningAnalyticsViewModel: ObservableObject {
             $0.date < $1.date
         })
         
-        guard let first = sorted.first, let last = sorted.last, last.balance < first.balance else { return nil }
+        guard let first = sorted.first, let last = sorted.last, last.balance <= first.balance else { return nil }
         
         let deltaY = last.balance - first.balance
         let deltaX = last.date.timeIntervalSince1970 - first.date.timeIntervalSince1970


### PR DESCRIPTION
fixed case when user hasn't spent any dollars/swipes, 
caused because of not checking the case where most recent balance is equal to the most recent max balance